### PR TITLE
[EUPI] Fix expansion for empty EUPI response

### DIFF
--- a/modules/expansion/eupi.py
+++ b/modules/expansion/eupi.py
@@ -53,8 +53,7 @@ def handle_expansion(pyeupi, url):
             misperrors['error'] = 'Unknown in the EUPI service'
             return misperrors
     else:
-        misperrors['error'] = 'Error in EUPI lookup'
-        return misperrors
+        return {'results': [{'types': mispattributes['output'], 'values': ''}]}
 
 
 def handle_hover(pyeupi, url):


### PR DESCRIPTION
In #24, I edited the expansion code to avoid an 500 error when the EUPI API call answers with an empty message (i.e. no result).

A colleague at EUPI pointed to me that it would be better to have MISP display an empty enrichment page instead of an error message.

This commit aims to fix that. But maybe there is a better way to tell the user that in fact there is no enrichment that can be offered by the module for those inputs?