### PR TITLE
Add tags on import with ioc import module

### DIFF
--- a/misp_modules/modules/import_mod/openiocimport.py
+++ b/misp_modules/modules/import_mod/openiocimport.py
@@ -5,92 +5,92 @@ from pymisp.tools import openioc
 
 misperrors = {'error': 'Error'}
 userConfig = {
-			'not save ioc': {
-				'type': 'Boolean',
-				'message': 'If you check this box, IOC file will not save as an attachment in MISP'
-			},
-			'default tag': {
-				'type': 'String',
-				'message': 'Add tags spaced by a comma (tlp:white,misp:threat-level="no-risk")',
-				'validation' : '0'
-			}
-		}
+            'not save ioc': {
+                'type': 'Boolean',
+                'message': 'If you check this box, IOC file will not save as an attachment in MISP'
+            },
+            'default tag': {
+                'type': 'String',
+                'message': 'Add tags spaced by a comma (tlp:white,misp:threat-level="no-risk")',
+                'validation' : '0'
+            }
+        }
 
 inputSource = ['file']
 
 moduleinfo = {'version': '0.1', 'author': 'Raphaël Vinot',
-			'description': 'Import OpenIOC package',
-			'module-type': ['import']}
+            'description': 'Import OpenIOC package',
+            'module-type': ['import']}
 
 moduleconfig = []
 
 
 def handler(q=False):
-	# Just in case we have no data
-	if q is False:
-		return False
+    # Just in case we have no data
+    if q is False:
+        return False
 
-	# The return value
-	r = {'results': []}
+    # The return value
+    r = {'results': []}
 
-	# Load up that JSON
-	q = json.loads(q)
+    # Load up that JSON
+    q = json.loads(q)
 
-	# It's b64 encoded, so decode that stuff
-	package = base64.b64decode(q.get("data")).decode('utf-8')
+    # It's b64 encoded, so decode that stuff
+    package = base64.b64decode(q.get("data")).decode('utf-8')
 
-	# If something really weird happened
-	if not package:
-		return json.dumps({"success": 0})
+    # If something really weird happened
+    if not package:
+        return json.dumps({"success": 0})
 
-	pkg = openioc.load_openioc(package)
+    pkg = openioc.load_openioc(package)
 
-	if q.get('config'):
-		if q['config'].get('not save ioc') == "0":
-			addFile = {
-					"values": [q.get('filename')],
-					"types": ['attachment'],
-					"categories": ['Support Tool'],
-					"data" : q.get('data'),
-					}
-			# add tag
-			if q['config'].get('default tag') is not None:
-				addFile["tags"] = q['config']['default tag'].split(",")
-			# add file as attachment
-			r["results"].append(addFile)
+    if q.get('config'):
+        if q['config'].get('not save ioc') == "0":
+            addFile = {
+                    "values": [q.get('filename')],
+                    "types": ['attachment'],
+                    "categories": ['Support Tool'],
+                    "data" : q.get('data'),
+                    }
+            # add tag
+            if q['config'].get('default tag') is not None:
+                addFile["tags"] = q['config']['default tag'].split(",")
+            # add file as attachment
+            r["results"].append(addFile)
 
 
-	# return all attributes
-	for attrib in pkg.attributes:
-		toAppend = {
-			"values": [attrib.value],
-			"types": [attrib.type],
-			"categories": [attrib.category],
-			"comment":attrib.comment
-			}
-		# add tag 
-		if q['config'].get('default tag') is not None:
-			toAppend["tags"] = q['config']['default tag'].split(",")
+    # return all attributes
+    for attrib in pkg.attributes:
+        toAppend = {
+            "values": [attrib.value],
+            "types": [attrib.type],
+            "categories": [attrib.category],
+            "comment":attrib.comment
+            }
+        # add tag 
+        if q['config'].get('default tag') is not None:
+            toAppend["tags"] = q['config']['default tag'].split(",")
 
-		r["results"].append(toAppend)
-	return r
+        r["results"].append(toAppend)
+    return r
 
 
 def introspection():
-	modulesetup = {}
-	try:
-		userConfig
-		modulesetup['userConfig'] = userConfig
-	except NameError:
-		pass
-	try:
-		inputSource
-		modulesetup['inputSource'] = inputSource
-	except NameError:
-		pass
-	return modulesetup
+    modulesetup = {}
+    try:
+        userConfig
+        modulesetup['userConfig'] = userConfig
+    except NameError:
+        pass
+    try:
+        inputSource
+        modulesetup['inputSource'] = inputSource
+    except NameError:
+        pass
+    return modulesetup
 
 
 def version():
-	moduleinfo['config'] = moduleconfig
-	return moduleinfo
+    moduleinfo['config'] = moduleconfig
+    return moduleinfo

--- a/misp_modules/modules/import_mod/openiocimport.py
+++ b/misp_modules/modules/import_mod/openiocimport.py
@@ -5,79 +5,92 @@ from pymisp.tools import openioc
 
 misperrors = {'error': 'Error'}
 userConfig = {
-               'not save ioc': {
-                 'type': 'Boolean',
-                 'message': 'If you check this box, IOC file will not save as an attachment in MISP'
-               }
-           }
+			'not save ioc': {
+				'type': 'Boolean',
+				'message': 'If you check this box, IOC file will not save as an attachment in MISP'
+			},
+			'default tag': {
+				'type': 'String',
+				'message': 'Add tags spaced by a comma (tlp:white,misp:threat-level="no-risk")',
+				'validation' : '0'
+			}
+		}
 
 inputSource = ['file']
 
 moduleinfo = {'version': '0.1', 'author': 'Raphaël Vinot',
-              'description': 'Import OpenIOC package',
-              'module-type': ['import']}
+			'description': 'Import OpenIOC package',
+			'module-type': ['import']}
 
 moduleconfig = []
 
 
 def handler(q=False):
-    # Just in case we have no data
-    if q is False:
-        return False
+	# Just in case we have no data
+	if q is False:
+		return False
 
-    # The return value
-    r = {'results': []}
+	# The return value
+	r = {'results': []}
 
-    # Load up that JSON
-    q = json.loads(q)
+	# Load up that JSON
+	q = json.loads(q)
 
-    # It's b64 encoded, so decode that stuff
-    package = base64.b64decode(q.get("data")).decode('utf-8')
+	# It's b64 encoded, so decode that stuff
+	package = base64.b64decode(q.get("data")).decode('utf-8')
 
-    # If something really weird happened
-    if not package:
-        return json.dumps({"success": 0})
+	# If something really weird happened
+	if not package:
+		return json.dumps({"success": 0})
 
-    pkg = openioc.load_openioc(package)
+	pkg = openioc.load_openioc(package)
 
-    if q.get('config'):
-        if q['config'].get('not save ioc') == "0":
+	if q.get('config'):
+		if q['config'].get('not save ioc') == "0":
+			addFile = {
+					"values": [q.get('filename')],
+					"types": ['attachment'],
+					"categories": ['Support Tool'],
+					"data" : q.get('data'),
+					}
+			# add tag
+			if q['config'].get('default tag') is not None:
+				addFile["tags"] = q['config']['default tag'].split(",")
+			# add file as attachment
+			r["results"].append(addFile)
 
-            # add origin file as attachment
-            if q.get("filename"):
-                r["results"].append({
-                    "values": [q.get('filename')],
-                    "types": ['attachment'],
-                    "categories": ['Support Tool'],
-                    "data" : q.get('data'),
-                    })
 
-    # return all attributes
-    for attrib in pkg.attributes:
-        r["results"].append({
-            "values": [attrib.value],
-            "types": [attrib.type],
-            "categories": [attrib.category],
-            "comment":attrib.comment})
+	# return all attributes
+	for attrib in pkg.attributes:
+		toAppend = {
+			"values": [attrib.value],
+			"types": [attrib.type],
+			"categories": [attrib.category],
+			"comment":attrib.comment
+			}
+		# add tag 
+		if q['config'].get('default tag') is not None:
+			toAppend["tags"] = q['config']['default tag'].split(",")
 
-    return r
+		r["results"].append(toAppend)
+	return r
 
 
 def introspection():
-    modulesetup = {}
-    try:
-        userConfig
-        modulesetup['userConfig'] = userConfig
-    except NameError:
-        pass
-    try:
-        inputSource
-        modulesetup['inputSource'] = inputSource
-    except NameError:
-        pass
-    return modulesetup
+	modulesetup = {}
+	try:
+		userConfig
+		modulesetup['userConfig'] = userConfig
+	except NameError:
+		pass
+	try:
+		inputSource
+		modulesetup['inputSource'] = inputSource
+	except NameError:
+		pass
+	return modulesetup
 
 
 def version():
-    moduleinfo['config'] = moduleconfig
-    return moduleinfo
+	moduleinfo['config'] = moduleconfig
+	return moduleinfo


### PR DESCRIPTION
A new field is added to specify tag.

**This functionality need this pull/request : https://github.com/MISP/MISP/pull/2179**
 

If you have the good right, tag will be created and added to each attributes.
if you don't have the good right, you need to specify a valid tag.

Add tags with comma : 
![ioc import 2](https://cloud.githubusercontent.com/assets/17462115/25938998/a01b602a-3631-11e7-9ed3-c936656612b4.png)

Select for each attributes : 
![ioc import 3](https://cloud.githubusercontent.com/assets/17462115/25939029/b7b553c6-3631-11e7-9fc3-27b479a5e99f.png)

See result \^^/
![ioc import 4](https://cloud.githubusercontent.com/assets/17462115/25939113/069d6ee2-3632-11e7-8c11-dcd660391586.png)
