### PR TITLE
Updated csv import following our recent discussions

### DIFF
--- a/misp_modules/modules/import_mod/csvimport.py
+++ b/misp_modules/modules/import_mod/csvimport.py
@@ -14,6 +14,7 @@ userConfig = {'header': {
 
 duplicatedFields = {'mispType': {'mispComment': 'comment'},
                     'attrField': {'attrComment': 'comment'}}
+attributesFields = ['type', 'value', 'category', 'to_ids', 'comment', 'distribution']
 
 class CsvParser():
     def __init__(self, header):
@@ -96,9 +97,12 @@ class CsvParser():
             elif h in duplicatedFields['attrField']:
                 # fields that should be considered as attribute fields
                 head.append(duplicatedFields['attrField'].get(h))
-            # otherwise, it is an attribute field
-            else:
+            # or, it could be an attribute field
+            elif h in attributesFields:
                 head.append(h)
+            # otherwise, it is not defined
+            else:
+                head.append('')
         # return list of indexes of the misp types, list of the misp types, remaining fields that will be attribute fields
         return list2pop, misp, list(reversed(head))
 


### PR DESCRIPTION
- Still using header from userConfig
- Added Boolean in userConfig to specify if the file is containing a header, to avoid importing it as attributes.
- Instructions for both configs available in the view of the import

This means users have to provide a header even if the file is already containing one, because I did not yet worked on a way to parse headers.
The fields in the header provided by users should be either:
- misp attribute types (in the list: https://github.com/MISP/PyMISP/blob/9648e31cddf9625f848c848ee9c0e7e395664e6d/pymisp/data/describeTypes.json#L605)
- or one of the fields of (the standard format of misp) attributes in the following list: type, value, to_ids, comment, category, distribution

Otherwise, values represented by a not valid header field (i.e not in one of the 2 points mentioned above) will not be imported

Will work later on parsing headers within files