### PR TITLE
Added (Multipage) PDF support to OCR Module, minor refactor

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -14,6 +14,7 @@ git+https://github.com/MISP/PyMISP.git#egg=pymisp
 git+https://github.com/sebdraven/pyonyphe#egg=pyonyphe
 pillow
 pytesseract
+wand
 SPARQLWrapper
 domaintools_api
 pygeoip

--- a/misp_modules/__init__.py
+++ b/misp_modules/__init__.py
@@ -193,7 +193,7 @@ class QueryModule(tornado.web.RequestHandler):
             if dict_payload.get('timeout'):
                 timeout = datetime.timedelta(seconds=int(dict_payload.get('timeout')))
             else:
-                timeout = datetime.timedelta(seconds=30)
+                timeout = datetime.timedelta(seconds=300)
             response = yield tornado.gen.with_timeout(timeout, self.run_request(jsonpayload))
             self.write(response)
         except tornado.gen.TimeoutError:

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -45,7 +45,7 @@ def handler(q=False):
     r = {'results': []}
     request = json.loads(q)
     document = base64.b64decode(request["data"])
-    if magic.from_buffer(document, mime=True).split("/")[1] == 'pdf':
+    if magic.from_buffer(document, mime=True).split("/")[1] == 'pdf': # Eventually this could be replaced with wand.obj.format
         print("PDF Detected")
         with WImage(blob=document) as pdf:
             pages=len(pdf.sequence)

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -42,7 +42,7 @@ def handler(q=False):
     document = base64.b64decode(request["data"])
     document = WImage(blob=document)
     if document.format == 'PDF':
-        with WImage(blob=document) as pdf:
+        with document as pdf:
             # Get number of pages
             pages=len(pdf.sequence)
             print(f"PDF with {pages} page(s) detected")

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -32,8 +32,8 @@ def handler(q=False):
             pages=len(pdf.sequence)
             img = WImage(width=pdf.width, height=pdf.height * pages)
             for p in range(pages):
-                img.composite(pdf.sequence[p], top=pdf.height * i, left=0)
-        image = document
+                img.composite(pdf.sequence[p], top=pdf.height * p, left=0)
+    image = document
 
     image_file = BytesIO(image)
     image_file.seek(0)

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import base64
 from io import BytesIO

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -56,16 +56,16 @@ def handler(q=False):
         with document as pdf:
             # Get number of pages
             pages=len(pdf.sequence)
-            log.debug(f"PDF with {pages} page(s) detected")
+            log.debug("PDF with {} page(s) detected".format(pages))
             # Create new image object where the height will be the number of pages. With huge PDFs this will overflow, break, consume silly memory etc…
             img = WImage(width=pdf.width, height=pdf.height * pages)
             # Cycle through pages and stitch it together to one big file
             for p in range(pages):
-                log.debug(f"Stitching page {p+1}")
+                log.debug("Stitching page {}".format(p+1))
                 image = img.composite(pdf.sequence[p], top=pdf.height * p, left=0)
             # Create a png blob
             image = img.make_blob('png')
-            log.debug(f"Final image size is {pdf.width}x{pdf.height*(p+1)}")
+            log.debug("Final image size is {}x{}".format(pdf.width, pdf.height*(p+1)))
     else:
         image = document
 

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -61,11 +61,11 @@ def handler(q=False):
             img = WImage(width=pdf.width, height=pdf.height * pages)
             # Cycle through pages and stitch it together to one big file
             for p in range(pages):
-                log.debug(f"Stitching page {p}")
+                log.debug(f"Stitching page {p+1}")
                 image = img.composite(pdf.sequence[p], top=pdf.height * p, left=0)
             # Create a png blob
             image = img.make_blob('png')
-            log.debug(f"Final image size is {pdf.width}x{pdf.height*p}")
+            log.debug(f"Final image size is {pdf.width}x{pdf.height*(p+1)}")
     else:
         image = document
 

--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -2,6 +2,16 @@ import json
 import base64
 from io import BytesIO
 
+import logging
+
+log = logging.getLogger('ocr')
+log.setLevel(logging.DEBUG)
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+log.addHandler(ch)
+
 misperrors = {'error': 'Error'}
 userConfig = {};
 
@@ -45,14 +55,16 @@ def handler(q=False):
         with document as pdf:
             # Get number of pages
             pages=len(pdf.sequence)
-            print(f"PDF with {pages} page(s) detected")
+            log.debug(f"PDF with {pages} page(s) detected")
             # Create new image object where the height will be the number of pages. With huge PDFs this will overflow, break, consume silly memory etc…
             img = WImage(width=pdf.width, height=pdf.height * pages)
             # Cycle through pages and stitch it together to one big file
             for p in range(pages):
+                log.debug(f"Stitching page {p}")
                 image = img.composite(pdf.sequence[p], top=pdf.height * p, left=0)
             # Create a png blob
             image = img.make_blob('png')
+            log.debug(f"Final image size is {pdf.width}x{pdf.height*p}")
     else:
         image = document
 


### PR DESCRIPTION
Quick and dirty PDF implementation using Wand: http://docs.wand-py.org/en/0.4.4/
Refactored the python module loading, in case the module is not installed it will yield an error for MISP to display.

It will stitch together one big PNG out of all the pages included in a PDF.

Gotchas: 

- Huge PDFs might fail on timeouts, solution -> async foo
- Weirdly formatted PDFs might fail, solution -> Print it and recreate the PDF, resubmit