### PR TITLE
New macaddress.io hover module added

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For more information: [Extending MISP with Python modules](https://www.circl.lu/
 * [hashdd](misp_modules/modules/expansion/hashdd.py) - a hover module to check file hashes against [hashdd.com](http://www.hashdd.com) including NSLR dataset.
 * [IPASN](misp_modules/modules/expansion/ipasn.py) - a hover and expansion to get the BGP ASN of an IP address.
 * [iprep](misp_modules/modules/expansion/iprep.py) - an expansion module to get IP reputation from packetmail.net.
+* [macaddress.io](misp_modules/modules/expansion/macaddress_io.py) - a hover module to retrieve vendor details and other information regarding a given MAC address or an OUI. [MAC address Vendor Lookup](https://macaddress.io)
 * [onyphe](misp_modules/modules/expansion/onyphe.py) - a modules to process queries on Onyphe.
 * [onyphe_full](misp_modules/modules/expansion/onyphe_full.py) - a modules to process full queries on Onyphe.
 * [OTX](misp_modules/modules/expansion/otx.py) - an expansion module for [OTX](https://otx.alienvault.com/).

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -24,3 +24,4 @@ oauth2
 yara
 sigmatools
 stix2-patterns
+maclookup

--- a/misp_modules/modules/expansion/macaddress_io.py
+++ b/misp_modules/modules/expansion/macaddress_io.py
@@ -1,0 +1,119 @@
+import json
+
+from maclookup import ApiClient, exceptions
+
+misperrors = {
+    'error': 'Error'
+}
+
+mispattributes = {
+    'input': ['mac-address'],
+}
+
+moduleinfo = {
+    'version': '1.0',
+    'author': 'CodeLine OY - macaddress.io',
+    'description': 'MISP hover module for macaddress.io',
+    'module-type': ['hover']
+}
+
+moduleconfig = ['api_key']
+
+
+def handler(q=False):
+    if q is False:
+        return False
+
+    request = json.loads(q)
+
+    if request.get('mac-address'):
+        mac_address = request['mac-address']
+    else:
+        return False
+
+    if request['config'].get('api_key'):
+        api_key = request['config'].get('api_key')
+
+    else:
+        misperrors['error'] = 'Authorization required'
+        return misperrors
+
+    api_client = ApiClient(api_key)
+
+    try:
+        response = api_client.get(mac_address)
+
+    except exceptions.EmptyResponseException:
+        misperrors['error'] = 'Empty response'
+        return misperrors
+
+    except exceptions.UnparsableResponseException:
+        misperrors['error'] = 'Unparsable response'
+        return misperrors
+
+    except exceptions.ServerErrorException:
+        misperrors['error'] = 'Internal server error'
+        return misperrors
+
+    except exceptions.UnknownOutputFormatException:
+        misperrors['error'] = 'Unknown output'
+        return misperrors
+
+    except exceptions.AuthorizationRequiredException:
+        misperrors['error'] = 'Authorization required'
+        return misperrors
+
+    except exceptions.AccessDeniedException:
+        misperrors['error'] = 'Access denied'
+        return misperrors
+
+    except exceptions.InvalidMacOrOuiException:
+        misperrors['error'] = 'Invalid MAC or OUI'
+        return misperrors
+
+    except exceptions.NotEnoughCreditsException:
+        misperrors['error'] = 'Not enough credits'
+        return misperrors
+
+    except Exception:
+        misperrors['error'] = 'Unknown error'
+        return misperrors
+
+    results = {
+        'results': [
+            {'types': ['text'], 'values':
+                {
+                    'Valid MAC address': "True" if response.mac_address_details.is_valid else "False",
+
+                    'Transmission type': response.mac_address_details.transmission_type,
+                    'Administration type': response.mac_address_details.administration_type,
+
+                    'OUI': response.vendor_details.oui,
+                    'Vendor details are hidden': "True" if response.vendor_details.is_private else "False",
+
+                    'Company name': response.vendor_details.company_name,
+                    'Company\'s address': response.vendor_details.company_address,
+                    'County code': response.vendor_details.country_code,
+
+                    'Block found': "True" if response.block_details.block_found else "False",
+                    'The left border of the range': response.block_details.border_left,
+                    'The right border of the range': response.block_details.border_right,
+                    'The total number of MAC addresses in this range': response.block_details.block_size,
+                    'Assignment block size': response.block_details.assignment_block_size,
+                    'Date when the range was allocated': response.block_details.date_created,
+                    'Date when the range was last updated': response.block_details.date_updated
+                }
+             }
+        ]
+    }
+
+    return results
+
+
+def introspection():
+    return mispattributes
+
+
+def version():
+    moduleinfo['config'] = moduleconfig
+    return moduleinfo


### PR DESCRIPTION
New ‘macaddress.io’ module added.

It is based on the https://macaddress.io API.
The module allows retrieving vendor details and other information regarding a given MAC address or an OUI.