### PR TITLE
chg: [pdfexport] Fix pdf export, by calling new PyMISP tool for Misp Event export

### DIFF
--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -7,60 +7,25 @@ import shlex
 import subprocess
 import base64
 
-from pymisp import MISPEvent
+from pymisp import MISPEvent, reportlab_generator
 
 
 misperrors = {'error': 'Error'}
 
-moduleinfo = {'version': '42',
-              'author': 'Raphaël Vinot',
+moduleinfo = {'version': '2',
+              'author': 'Vincent Falconieri (prev. Raphaël Vinot)',
               'description': 'Simple export to PDF',
               'module-type': ['export'],
               'require_standard_format': True}
 
 moduleconfig = []
-
 mispattributes = {}
+
 outputFileExtension = "pdf"
 responseType = "application/pdf"
 
 types_to_attach = ['ip-dst', 'url', 'domain']
 objects_to_attach = ['domain-ip']
-
-headers = """
-:toc: right
-:toclevels: 1
-:toc-title: Daily Report
-:icons: font
-:sectanchors:
-:sectlinks:
-= Daily report by {org_name}
-{date}
-
-:icons: font
-
-"""
-
-event_level_tags = """
-IMPORTANT: This event is classified TLP:{value}.
-
-{expanded}
-
-"""
-
-attributes = """
-=== Indicator(s) of compromise
-
-{list_attributes}
-
-"""
-
-title = """
-== ({internal_id}) {title}
-
-{summary}
-
-"""
 
 
 class ReportGenerator():
@@ -79,6 +44,9 @@ class ReportGenerator():
         self.misp_event = MISPEvent()
         self.misp_event.load(event)
 
+    '''
+
+    
     def attributes(self):
         if not self.misp_event.attributes:
             return ''
@@ -132,7 +100,7 @@ class ReportGenerator():
         self.report += self.title()
         self.report += self.event_level_tags()
         self.report += self.attributes()
-
+    '''
 
 def handler(q=False):
     if q is False:
@@ -144,19 +112,27 @@ def handler(q=False):
         return False
 
     for evt in request['data']:
+
+        '''
+        print(" DATA ")
         print(request['data'])
+
+        reportlab_generator.
         
         report = ReportGenerator()
         report.report_headers()
         report.from_event(evt)
         report.asciidoc()
 
-    command_line = 'asciidoctor-pdf -'
-    args = shlex.split(command_line)
-    with subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE) as process:
-        cmd_out, cmd_err = process.communicate(
-            input=report.report.encode('utf-8'))
-    return {'response': [], 'data': str(base64.b64encode(cmd_out), 'utf-8')}
+        print(" REPORT : ")
+        print(report)
+        '''
+    misp_event = MISPEvent()
+    misp_event.load(request['data'])
+
+    pdf = reportlab_generator.get_base64_from_buffer(reportlab_generator.convert_event_in_pdf_buffer(misp_event))
+
+    return {'response': [], 'data': str(pdf, 'utf-8')}
 
 
 def introspection():

--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -18,7 +18,9 @@ moduleinfo = {'version': '2',
               'module-type': ['export'],
               'require_standard_format': True}
 
-moduleconfig = []
+# config fields that your code expects from the site admin
+moduleconfig = ["MISP_base_url_for_dynamic_link", "MISP_name_for_metadata"]
+
 mispattributes = {}
 
 outputFileExtension = "pdf"
@@ -53,12 +55,19 @@ def handler(q=False):
     if 'data' not in request:
         return False
 
+    config = {}
+
+    # Construct config object for reportlab_generator
+    for config_item in moduleconfig :
+        if (request.get('config')) and (request['config'].get(config_item) is not None):
+            config[config_item] = request['config'].get(config_item)
+
     for evt in request['data']:
 
         misp_event = MISPEvent()
         misp_event.load(evt)
 
-        pdf = reportlab_generator.get_base64_from_value(reportlab_generator.convert_event_in_pdf_buffer(misp_event))
+        pdf = reportlab_generator.get_base64_from_value(reportlab_generator.convert_event_in_pdf_buffer(misp_event, config))
 
         return {'response': [], 'data': str(pdf, 'utf-8')}
 

--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -7,8 +7,10 @@ import shlex
 import subprocess
 import base64
 
-from pymisp import MISPEvent, reportlab_generator
+print("test PDF pdf export (reportlab generator import)")
 
+from pymisp import MISPEvent
+from pymisp.tools import reportlab_generator
 
 misperrors = {'error': 'Error'}
 
@@ -45,8 +47,6 @@ class ReportGenerator():
         self.misp_event.load(event)
 
     '''
-
-    
     def attributes(self):
         if not self.misp_event.attributes:
             return ''
@@ -127,12 +127,13 @@ def handler(q=False):
         print(" REPORT : ")
         print(report)
         '''
-    misp_event = MISPEvent()
-    misp_event.load(request['data'])
 
-    pdf = reportlab_generator.get_base64_from_buffer(reportlab_generator.convert_event_in_pdf_buffer(misp_event))
+        misp_event = MISPEvent()
+        misp_event.load(evt)
 
-    return {'response': [], 'data': str(pdf, 'utf-8')}
+        pdf = reportlab_generator.get_base64_from_value(reportlab_generator.convert_event_in_pdf_buffer(misp_event))
+
+        return {'response': [], 'data': str(pdf, 'utf-8')}
 
 
 def introspection():
@@ -164,3 +165,8 @@ def introspection():
 def version():
     moduleinfo['config'] = moduleconfig
     return moduleinfo
+
+import pprint
+
+if __name__ == "__main__":
+    pprint.pprint("test")

--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -12,7 +12,7 @@ from pymisp import MISPEvent
 
 misperrors = {'error': 'Error'}
 
-moduleinfo = {'version': '1',
+moduleinfo = {'version': '42',
               'author': 'Raphaël Vinot',
               'description': 'Simple export to PDF',
               'module-type': ['export'],

--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -7,8 +7,6 @@ import shlex
 import subprocess
 import base64
 
-print("test PDF pdf export (reportlab generator import)")
-
 from pymisp import MISPEvent
 from pymisp.tools import reportlab_generator
 
@@ -46,62 +44,6 @@ class ReportGenerator():
         self.misp_event = MISPEvent()
         self.misp_event.load(event)
 
-    '''
-    def attributes(self):
-        if not self.misp_event.attributes:
-            return ''
-        list_attributes = []
-        for attribute in self.misp_event.attributes:
-            if attribute.type in types_to_attach:
-                list_attributes.append("* {}".format(attribute.value))
-        for obj in self.misp_event.Object:
-            if obj.name in objects_to_attach:
-                for attribute in obj.Attribute:
-                    if attribute.type in types_to_attach:
-                        list_attributes.append("* {}".format(attribute.value))
-        return attributes.format(list_attributes="\n".join(list_attributes))
-
-    def _get_tag_info(self, machinetag):
-        return self.taxonomies.revert_machinetag(machinetag)
-
-    def report_headers(self):
-        content = {'org_name': 'name',
-                   'date': date.today().isoformat()}
-        self.report += headers.format(**content)
-
-    def event_level_tags(self):
-        if not self.misp_event.Tag:
-            return ''
-        for tag in self.misp_event.Tag:
-            # Only look for TLP for now
-            if tag['name'].startswith('tlp'):
-                tax, predicate = self._get_tag_info(tag['name'])
-                return self.event_level_tags.format(value=predicate.predicate.upper(), expanded=predicate.expanded)
-
-    def title(self):
-        internal_id = ''
-        summary = ''
-        # Get internal refs for report
-        if not hasattr(self.misp_event, 'Object'):
-            return ''
-        for obj in self.misp_event.Object:
-            if obj.name != 'report':
-                continue
-            for a in obj.Attribute:
-                if a.object_relation == 'case-number':
-                    internal_id = a.value
-                if a.object_relation == 'summary':
-                    summary = a.value
-
-        return title.format(internal_id=internal_id, title=self.misp_event.info,
-                            summary=summary)
-
-    def asciidoc(self, lang='en'):
-        self.report += self.title()
-        self.report += self.event_level_tags()
-        self.report += self.attributes()
-    '''
-
 def handler(q=False):
     if q is False:
         return False
@@ -112,21 +54,6 @@ def handler(q=False):
         return False
 
     for evt in request['data']:
-
-        '''
-        print(" DATA ")
-        print(request['data'])
-
-        reportlab_generator.
-        
-        report = ReportGenerator()
-        report.report_headers()
-        report.from_event(evt)
-        report.asciidoc()
-
-        print(" REPORT : ")
-        print(report)
-        '''
 
         misp_event = MISPEvent()
         misp_event.load(evt)
@@ -165,8 +92,3 @@ def introspection():
 def version():
     moduleinfo['config'] = moduleconfig
     return moduleinfo
-
-import pprint
-
-if __name__ == "__main__":
-    pprint.pprint("test")

--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -144,6 +144,8 @@ def handler(q=False):
         return False
 
     for evt in request['data']:
+        print(request['data'])
+        
         report = ReportGenerator()
         report.report_headers()
         report.from_event(evt)


### PR DESCRIPTION
PDF were directly generated in misp-modules previously. Current code is much lighter, only calling PyMISP tool to create a PDF from a Misp Event

Linked to : https://github.com/MISP/PyMISP/pull/348