### PR TITLE
fix: [reportlab] Textual description parameter

### DIFF
--- a/misp_modules/modules/export_mod/pdfexport.py
+++ b/misp_modules/modules/export_mod/pdfexport.py
@@ -15,7 +15,7 @@ moduleinfo = {'version': '2',
               'require_standard_format': True}
 
 # config fields that your code expects from the site admin
-moduleconfig = ["MISP_base_url_for_dynamic_link", "MISP_name_for_metadata"]
+moduleconfig = ["MISP_base_url_for_dynamic_link", "MISP_name_for_metadata", "Activate_textual_description"]
 
 mispattributes = {}
 


### PR DESCRIPTION
Only adding a parameter for the PyMisp PDF export call.