### PR TITLE
Expansion module - File/URL submission to Cuckoo Sandbox

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -178,6 +178,25 @@ Module to query Crowdstrike Falcon.
 
 -----
 
+#### [cuckoo_submit](https://github.com/MISP/misp-modules/tree/master/misp_modules/modules/expansion/cuckoo_submit.py)
+
+<img src=logos/cuckoo.png height=60>
+
+An expansion module to submit files and URLs to Cuckoo Sandbox.
+- **features**:
+>The module takes a malware-sample, attachment, url or domain and submits it to Cuckoo Sandbox.
+> The returned task id can be used to retrieve results when the analysis completed.
+- **input**:
+>A malware-sample or attachment for files. A url or domain for URLs.
+- **output**:
+>A text field containing 'Cuckoo task id: <id>'
+- **references**:
+>https://cuckoosandbox.org/, https://cuckoo.sh/docs/
+- **requirements**:
+>Access to a Cuckoo Sandbox API and an API key if the API requires it. (api_url and api_key)
+
+-----
+
 #### [cve](https://github.com/MISP/misp-modules/tree/master/misp_modules/modules/expansion/cve.py)
 
 <img src=logos/cve.png height=60>
@@ -1081,7 +1100,13 @@ OSQuery export of a MISP event.
 
 Simple export of a MISP event to PDF.
 - **features**:
->The module takes care of the PDF file building, and work with any MISP Event. Except the requirement of asciidoctor, used to create the file, there is no special feature concerning the Event.
+>The module takes care of the PDF file building, and work with any MISP Event. Except the requirement of reportlab, used to create the file, there is no special feature concerning the Event. Some parameters can be given through the config dict. 'MISP_base_url_for_dynamic_link' is your MISP URL, to attach an hyperlink to your event on your MISP instance from the PDF. Keep it clear to avoid hyperlinks in the generated pdf.
+>  'MISP_name_for_metadata' is your CERT or MISP instance name. Used as text in the PDF' metadata
+>  'Activate_textual_description' is a boolean (True or void) to activate the textual description/header abstract of an event
+>  'Activate_galaxy_description' is a boolean (True or void) to activate the description of event related galaxies.
+>  'Activate_related_events' is a boolean (True or void) to activate the description of related event. Be aware this might leak information on confidential events linked to the current event !
+>  'Activate_internationalization_fonts' is a boolean (True or void) to activate Noto fonts instead of default fonts (Helvetica). This allows the support of CJK alphabet. Be sure to have followed the procedure to download Noto fonts (~70Mo) in the right place (/tools/pdf_fonts/Noto_TTF), to allow PyMisp to find and use them during PDF generation.
+>  'Custom_fonts_path' is a text (path or void) to the TTF file of your choice, to create the PDF with it. Be aware the PDF won't support bold/italic/special style anymore with this option 
 - **input**:
 >MISP Event
 - **output**:
@@ -1089,7 +1114,7 @@ Simple export of a MISP event to PDF.
 - **references**:
 >https://acrobat.adobe.com/us/en/acrobat/about-adobe-pdf.html
 - **requirements**:
->PyMISP, asciidoctor
+>PyMISP, reportlab
 
 -----
 

--- a/doc/expansion/cuckoo_submit.json
+++ b/doc/expansion/cuckoo_submit.json
@@ -1,0 +1,9 @@
+{
+    "description": "An expansion module to submit files and URLs to Cuckoo Sandbox.",
+    "logo": "logos/cuckoo.png",
+    "requirements": ["Access to a Cuckoo Sandbox API and an API key if the API requires it. (api_url and api_key)"],
+    "input": "A malware-sample or attachment for files. A url or domain for URLs.",
+    "output": "A text field containing 'Cuckoo task id: <id>'",
+    "references": ["https://cuckoosandbox.org/", "https://cuckoo.sh/docs/"],
+    "features": "The module takes a malware-sample, attachment, url or domain and submits it to Cuckoo Sandbox.\n The returned task id can be used to retrieve results when the analysis completed."
+}

--- a/misp_modules/modules/expansion/__init__.py
+++ b/misp_modules/modules/expansion/__init__.py
@@ -1,6 +1,6 @@
 from . import _vmray  # noqa
 
-__all__ = ['vmray_submit', 'bgpranking', 'circl_passivedns', 'circl_passivessl',
+__all__ = ['cuckoo_submit', 'vmray_submit', 'bgpranking', 'circl_passivedns', 'circl_passivessl',
            'countrycode', 'cve', 'dns', 'btc_steroids', 'domaintools', 'eupi',
            'farsight_passivedns', 'ipasn', 'passivetotal', 'sourcecache', 'virustotal',
            'whois', 'shodan', 'reversedns', 'geoip_country', 'wiki', 'iprep',

--- a/misp_modules/modules/expansion/cuckoo_submit.py
+++ b/misp_modules/modules/expansion/cuckoo_submit.py
@@ -9,25 +9,25 @@ import zipfile
 
 from requests.exceptions import RequestException
 
-log = logging.getLogger('cuckoo_submit')
+log = logging.getLogger("cuckoo_submit")
 log.setLevel(logging.DEBUG)
 sh = logging.StreamHandler(sys.stdout)
 sh.setLevel(logging.DEBUG)
 fmt = logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 sh.setFormatter(fmt)
 log.addHandler(sh)
 
 moduleinfo = {
-    "version": "0.1", 'author': "Evert Kors",
+    "version": "0.1", "author": "Evert Kors",
     "description": "Submit files and URLs to Cuckoo Sandbox",
     "module-type": ["expansion", "hover"]
 }
 misperrors = {"error": "Error"}
-moduleconfig = ["cuckoo_api", "api_key"]
+moduleconfig = ["api_url", "api_key"]
 mispattributes = {
-    "input": ["attachment', 'malware-sample", "url", "domain"],
+    "input": ["attachment", "malware-sample", "url", "domain"],
     "output": ["text"]
 }
 
@@ -56,7 +56,7 @@ class CuckooAPI(object):
             response = requests.post(
                 urllib.parse.urljoin(self.api_url, endpoint),
                 files=files, data=data,
-                headers={"Authorization: Bearer {}".format(self.api_key)}
+                headers={"Authorization": "Bearer {}".format(self.api_key)}
             )
         except RequestException as e:
             log.error("Failed to submit sample to Cuckoo Sandbox. %s", e)
@@ -64,6 +64,10 @@ class CuckooAPI(object):
 
         if response.status_code == 401:
             raise APIKeyError("Invalid or no Cuckoo Sandbox API key provided")
+
+        if response.status_code != 200:
+            log.error("Invalid Cuckoo API response")
+            return None
 
         return response.json()
 
@@ -145,5 +149,5 @@ def introspection():
 
 
 def version():
-    moduleinfo['config'] = moduleconfig
+    moduleinfo["config"] = moduleconfig
     return moduleinfo

--- a/misp_modules/modules/expansion/cuckoo_submit.py
+++ b/misp_modules/modules/expansion/cuckoo_submit.py
@@ -1,0 +1,62 @@
+import json
+import requests
+
+misperrors = {'error': 'Error'}
+mispattributes = {
+        'input': ['url'],
+        'output': ['text']
+}
+
+# possible module-types: 'expansion', 'hover' or both
+moduleinfo = {'version': '1', 'author': 'Evert Kors',
+              'description': 'MODULE_DESCRIPTION',
+              'module-type': ['expansion', 'hover']}
+
+# config fields that your code expects from the site admin
+moduleconfig = ['cuckoo_api']
+
+
+def handler(q=False):
+    if q is False:
+        return False
+    request = json.loads(q)
+    config = request.get('config')
+    if config is None:
+        misperrors['error'] = 'config is missing'
+        return misperrors
+
+    cuck = config.get('cuckoo_api')
+    if cuck is None:
+        misperrors['error'] = 'cuckoo api url is missing'
+        return misperrors
+
+    # The url to submit
+    url = request.get('url')
+
+    HEADERS = {"Authorization": "Bearer S4MPL3"}
+
+    urls = [
+        url
+    ]
+
+    try:
+        r = requests.post(
+            "%s/tasks/create/submit" % (cuck),
+            headers=HEADERS,
+            data={"strings": "\n".join(urls)}
+        )
+    except Exception as e:
+        misperrors['error'] = str(e)
+        return misperrors
+
+    r = {'results': [{'types': "text", 'values': "cool"}]}
+    return r
+
+
+def introspection():
+    return mispattributes
+
+
+def version():
+    moduleinfo['config'] = moduleconfig
+    return moduleinfo

--- a/misp_modules/modules/expansion/cuckoo_submit.py
+++ b/misp_modules/modules/expansion/cuckoo_submit.py
@@ -1,56 +1,143 @@
+import base64
+import io
 import json
+import logging
 import requests
+import sys
+import urllib.parse
+import zipfile
 
-misperrors = {'error': 'Error'}
+from requests.exceptions import RequestException
+
+log = logging.getLogger('cuckoo_submit')
+log.setLevel(logging.DEBUG)
+sh = logging.StreamHandler(sys.stdout)
+sh.setLevel(logging.DEBUG)
+fmt = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+sh.setFormatter(fmt)
+log.addHandler(sh)
+
+moduleinfo = {
+    "version": "0.1", 'author': "Evert Kors",
+    "description": "Submit files and URLs to Cuckoo Sandbox",
+    "module-type": ["expansion", "hover"]
+}
+misperrors = {"error": "Error"}
+moduleconfig = ["cuckoo_api", "api_key"]
 mispattributes = {
-        'input': ['url'],
-        'output': ['text']
+    "input": ["attachment', 'malware-sample", "url", "domain"],
+    "output": ["text"]
 }
 
-# possible module-types: 'expansion', 'hover' or both
-moduleinfo = {'version': '1', 'author': 'Evert Kors',
-              'description': 'MODULE_DESCRIPTION',
-              'module-type': ['expansion', 'hover']}
 
-# config fields that your code expects from the site admin
-moduleconfig = ['cuckoo_api']
+class APIKeyError(RequestException):
+    """Raised if the Cuckoo API returns a 401. This means no or an invalid
+    bearer token was supplied."""
+    pass
+
+
+class CuckooAPI(object):
+
+    def __init__(self, api_url, api_key=""):
+        self.api_key = api_key
+        if not api_url.startswith("http"):
+            api_url = "https://{}".format(api_url)
+
+        self.api_url = api_url
+
+    def _post_api(self, endpoint, files=None, data={}):
+        data.update({
+            "owner": "MISP"
+        })
+
+        try:
+            response = requests.post(
+                urllib.parse.urljoin(self.api_url, endpoint),
+                files=files, data=data,
+                headers={"Authorization: Bearer {}".format(self.api_key)}
+            )
+        except RequestException as e:
+            log.error("Failed to submit sample to Cuckoo Sandbox. %s", e)
+            return None
+
+        if response.status_code == 401:
+            raise APIKeyError("Invalid or no Cuckoo Sandbox API key provided")
+
+        return response.json()
+
+    def create_task(self, filename, fp):
+        response = self._post_api(
+            "/tasks/create/file", files={"file": (filename, fp)}
+        )
+        if not response:
+            return False
+
+        return response["task_id"]
+
+    def create_url(self, url):
+        response = self._post_api(
+            "/tasks/create/url", data={"url": url}
+        )
+        if not response:
+            return False
+
+        return response["task_id"]
 
 
 def handler(q=False):
     if q is False:
         return False
+
     request = json.loads(q)
-    config = request.get('config')
-    if config is None:
-        misperrors['error'] = 'config is missing'
+
+    # See if the API URL was provided. The API key is optional, as it can
+    # be disabled in the Cuckoo API settings.
+    api_url = request["config"].get("api_url")
+    api_key = request["config"].get("api_key", "")
+    if not api_url:
+        misperrors["error"] = "No Cuckoo API URL provided"
         return misperrors
 
-    cuck = config.get('cuckoo_api')
-    if cuck is None:
-        misperrors['error'] = 'cuckoo api url is missing'
-        return misperrors
+    url = request.get("url") or request.get("domain")
+    data = request.get("data")
+    filename = None
+    if data:
+        data = base64.b64decode(data)
 
-    # The url to submit
-    url = request.get('url')
+        if "malware-sample" in request:
+            filename = request.get("malware-sample").split("|", 1)[0]
+            with zipfile.ZipFile(io.BytesIO(data)) as zipf:
+                data = zipf.read(zipf.namelist()[0], pwd=b"infected")
 
-    HEADERS = {"Authorization": "Bearer S4MPL3"}
+        elif "attachment" in request:
+            filename = request.get("attachment")
 
-    urls = [
-        url
-    ]
-
+    cuckoo_api = CuckooAPI(api_url=api_url, api_key=api_key)
+    task_id = None
     try:
-        r = requests.post(
-            "%s/tasks/create/submit" % (cuck),
-            headers=HEADERS,
-            data={"strings": "\n".join(urls)}
-        )
-    except Exception as e:
-        misperrors['error'] = str(e)
+        if url:
+            log.debug("Submitting URL to Cuckoo Sandbox %s", api_url)
+            task_id = cuckoo_api.create_url(url)
+        elif data and filename:
+            log.debug("Submitting file to Cuckoo Sandbox %s", api_url)
+            task_id = cuckoo_api.create_task(
+                filename=filename, fp=io.BytesIO(data)
+            )
+    except APIKeyError as e:
+        misperrors["error"] = "Failed to submit to Cuckoo: {}".format(e)
         return misperrors
 
-    r = {'results': [{'types': "text", 'values': "cool"}]}
-    return r
+    if not task_id:
+        misperrors["error"] = "File or URL submission failed"
+        return misperrors
+
+    return {
+        "results": [
+            {"types": "text", "values": "Cuckoo task id: {}".format(task_id)}
+        ]
+    }
 
 
 def introspection():


### PR DESCRIPTION
Hi team! :smile: 

This PR adds an expansion module that allows for malware-sample, attachment, url, and domain submission to a Cuckoo Sandbox API.

Before it can be used, the user has to configure the URL to a Cuckoo API. The API key is optional, since it can be disabled in Cuckoo.

It was tested using the VM that is provided here: https://www.circl.lu/misp-images/latest/