### PR TITLE
Fix ipasn.py bug

### DIFF
--- a/misp_modules/modules/expansion/ipasn.py
+++ b/misp_modules/modules/expansion/ipasn.py
@@ -28,7 +28,7 @@ def handler(q=False):
     if not values:
         misperrors['error'] = 'Unable to find the history of this IP'
         return misperrors
-    return {'results': [{'types': mispattributes['output'], 'values': values}]}
+    return {'results': [{'types': mispattributes['output'], 'values': [str(values)]}]}
 
 
 def introspection():


### PR DESCRIPTION
`ipasn.py` is currently returning an array which results in 

![Screen Shot 2020-01-07 at 18 59 23](https://user-images.githubusercontent.com/19863605/71917235-e3c27100-317f-11ea-92f0-ae6cea49885b.png)

This PR converts the value to string