### PR TITLE
fix: [VT] Disable SHA512 query for VT

### DIFF
--- a/misp_modules/modules/expansion/virustotal.py
+++ b/misp_modules/modules/expansion/virustotal.py
@@ -3,12 +3,12 @@ import json
 import requests
 
 misperrors = {'error': 'Error'}
-mispattributes = {'input': ['hostname', 'domain', "ip-src", "ip-dst", "md5", "sha1", "sha256", "sha512", "url"],
+mispattributes = {'input': ['hostname', 'domain', "ip-src", "ip-dst", "md5", "sha1", "sha256", "url"],
                   'format': 'misp_standard'}
 
 # possible module-types: 'expansion', 'hover' or both
 moduleinfo = {'version': '4', 'author': 'Hannah Ward',
-              'description': 'Get information from virustotal',
+              'description': 'Get information from VirusTotal',
               'module-type': ['expansion']}
 
 # config fields that your code expects from the site admin
@@ -25,8 +25,7 @@ class VirusTotalParser(object):
         self.input_types_mapping = {'ip-src': self.parse_ip, 'ip-dst': self.parse_ip,
                                     'domain': self.parse_domain, 'hostname': self.parse_domain,
                                     'md5': self.parse_hash, 'sha1': self.parse_hash,
-                                    'sha256': self.parse_hash, 'sha512': self.parse_hash,
-                                    'url': self.parse_url}
+                                    'sha256': self.parse_hash, 'url': self.parse_url}
 
     def query_api(self, attribute):
         self.attribute = MISPAttribute()

--- a/misp_modules/modules/expansion/virustotal_public.py
+++ b/misp_modules/modules/expansion/virustotal_public.py
@@ -3,10 +3,10 @@ import json
 import requests
 
 misperrors = {'error': 'Error'}
-mispattributes = {'input': ['hostname', 'domain', "ip-src", "ip-dst", "md5", "sha1", "sha256", "sha512", "url"],
+mispattributes = {'input': ['hostname', 'domain', "ip-src", "ip-dst", "md5", "sha1", "sha256", "url"],
                   'format': 'misp_standard'}
 moduleinfo = {'version': '1', 'author': 'Christian Studer',
-              'description': 'Get information from virustotal public API v2.',
+              'description': 'Get information from VirusTotal public API v2.',
               'module-type': ['expansion', 'hover']}
 
 moduleconfig = ['apikey']
@@ -155,7 +155,7 @@ ip = ('ip', IpQuery)
 file = ('resource', HashQuery)
 misp_type_mapping = {'domain': domain, 'hostname': domain, 'ip-src': ip,
                      'ip-dst': ip, 'md5': file, 'sha1': file, 'sha256': file,
-                     'sha512': file, 'url': ('resource', UrlQuery)}
+                     'url': ('resource', UrlQuery)}
 
 
 def parse_error(status_code):


### PR DESCRIPTION
VirusTotal can be query just by MD5, SHA1 and SHA256:

> The resource argument can be the MD5, SHA-1 or SHA-256
- https://developers.virustotal.com/reference#file-report

 so for me doesn't make sense to allow users to try query also for SHA512.

 