### PR TITLE
fix: [circl_passivedns] Return not found error

### DIFF
--- a/misp_modules/modules/expansion/circl_passivedns.py
+++ b/misp_modules/modules/expansion/circl_passivedns.py
@@ -30,6 +30,11 @@ class PassiveDNSParser():
         except Exception:
             self.result = {'error': 'There is an authentication error, please make sure you supply correct credentials.'}
             return
+
+        if not results:
+            self.result = {'error': 'Not found'}
+            return
+
         mapping = {'count': 'counter', 'origin': 'text',
                    'time_first': 'datetime', 'rrtype': 'text',
                    'rrname': 'text', 'rdata': 'text',

--- a/misp_modules/modules/expansion/circl_passivessl.py
+++ b/misp_modules/modules/expansion/circl_passivessl.py
@@ -37,6 +37,11 @@ class PassiveSSLParser():
         except Exception:
             self.result = {'error': 'There is an authentication error, please make sure you supply correct credentials.'}
             return
+
+        if not results:
+            self.result = {'error': 'Not found'}
+            return
+
         for ip_address, certificates in results.items():
             ip_uuid = self._handle_ip_attribute(ip_address)
             for certificate in certificates['certificates']:


### PR DESCRIPTION
If passivedns returns empty response, return Not found error instead of error in log