### PR TITLE
fixed typo causing firstSeen and lastSeen to not be pulled from enric…

### DIFF
--- a/misp_modules/modules/expansion/trustar_enrich.py
+++ b/misp_modules/modules/expansion/trustar_enrich.py
@@ -39,7 +39,7 @@ class TruSTARParser:
 
     # Relevant fields from each TruSTAR endpoint
     SUMMARY_FIELDS = ["severityLevel", "source", "score", "attributes"]
-    METADATA_FIELDS = ["sightings", "first_seen", "last_seen", "tags"]
+    METADATA_FIELDS = ["sightings", "firstSeen", "lastSeen", "tags"]
 
     REPORT_BASE_URL = "https://station.trustar.co/constellation/reports/{}"
 


### PR DESCRIPTION
…hment data

_What?_ -- This PR addresses an issue seen in QA where the firstSeen and lastSeen timestamps are missing from enrichment data pulled from TruSTAR

_Why?_ -- These timestamps are a user expectation.

_How?_ -- The variables in the original implementation were written as `first_seen` and `last_seen` rather than `firstSeen` and `lastSeen` - so this was corrected.