### PR TITLE
Corrected VMray rest API import

### DIFF
--- a/misp_modules/modules/expansion/vmray_submit.py
+++ b/misp_modules/modules/expansion/vmray_submit.py
@@ -19,7 +19,7 @@ from distutils.util import strtobool
 import io
 import zipfile
 
-from _vmray.vmray_rest_api import VMRayRESTAPI
+from _vmray.rest_api import VMRayRESTAPI
 
 misperrors = {'error': 'Error'}
 mispattributes = {'input': ['attachment', 'malware-sample'], 'output': ['text', 'sha1', 'sha256', 'md5', 'link']}


### PR DESCRIPTION
When loading misp-modules,  the VMray module `modules/expansion/vmray_submit.py` incorrectly imports the library, causing the misp-modules tests and service to fail with the error:

`WARNING: MISP modules vmray_submit failed due to No module named '_vmray.vmray_rest_api'`

 VMray's documentation and examples here: `https://pypi.org/project/vmray-rest-api/#history` also reflect this change as the correct import.

Excerpt from Example from file: submit_sample.py contained in `https://files.pythonhosted.org/packages/91/4d/24bcf6b329aaf7d79c80356adddf14102b0700ce6aafe96d67e036200869/vmray_rest_api-5.0.0.zip` 

```
#!/usr/bin/python3
"""Submit sample to VMRay Analyzer"""
[SNIP]

try:
    # try to import VMRay REST API
    from vmray.rest_api import VMRayRESTAPI, VMRayRESTAPIError
except ImportError:
    # if VMRAY REST API is not installed, try relative import
    sys.path.append(os.path.join(os.path.dirname(FILE), ".."))
    from vmray.rest_api import VMRayRESTAPI, VMRayRESTAPIError
    
[SNIP]
```