### PR TITLE
Farsight_passivedns module updated with new input types compatible with flex queries

### DIFF
--- a/misp_modules/modules/expansion/farsight_passivedns.py
+++ b/misp_modules/modules/expansion/farsight_passivedns.py
@@ -174,12 +174,15 @@ def add_flex_queries(flex):
 
 def flex_queries(client, lookup_args, name):
     response = {}
-    rdata = list(client.flex_rdata_regex(name.replace('.', '\\.'), **lookup_args))
-    if rdata:
-        response['flex_rdata'] = rdata
-    rrnames = list(client.flex_rrnames_regex(name.replace('.', '\\.'), **lookup_args))
-    if rrnames:
-        response['flex_rrnames'] = rrnames
+    name = name.replace('@', '.')
+    for feature in ('rdata', 'rrnames'):
+        to_call = getattr(client, f'flex_{feature}_regex')
+        results = list(to_call(name, **lookup_args))
+        for result in list(to_call(name.replace('.', '\\.'), **lookup_args)):
+            if result not in results:
+                results.append(result)
+        if results:
+            response[f'flex_{feature}'] = results
     return response
 
 


### PR DESCRIPTION
The initial way the module works remains the same:
- for domain, hostname or ip addresses input, we still call the usual `rdata` & `rrset` lookups
- We have the option to call flex queries as well

The new features include:
- New input types that are going to be used as input only for flex queries
- Flex queries have been updated:
  - with the new input types available, we make sure to replace every `@` by `.`
  - we make sure to query both the input value as is, and the input value with `.` escaped and merge the different results to avoid the duplication of results

Example with the following attribute as input:
```json
{
    "type": "email",
    "value": "tracking@dhl.com"
}
```
![image](https://user-images.githubusercontent.com/16307976/111680188-41d9f200-8822-11eb-9190-e2fe002afaf6.png)
