### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ sudo apt-get install python3-dev python3-pip libpq5 libjpeg-dev tesseract-ocr li
 sudo -u www-data virtualenv -p python3 /var/www/MISP/venv
 cd /usr/local/src/
 sudo chown -R www-data: .
-sudo git clone https://github.com/MISP/misp-modules.git
+sudo -u www-data git clone https://github.com/MISP/misp-modules.git
 cd misp-modules
 sudo -u www-data /var/www/MISP/venv/bin/pip install -I -r REQUIREMENTS
 sudo -u www-data /var/www/MISP/venv/bin/pip install .


### PR DESCRIPTION
With the current instructions /usr/local/src is set to be owned by www-data, then the clone is run the misp-modules directory is created as root. This leads to an error in the subsequent `pip install` command. The error is:
```
error: could not create 'misp_modules.egg-info': Permission denied
```
By cloning misp-modules as www-data we ensure that the user running the `pip install` commands has the ability to write to the directory. 