### PR TITLE
Add libcaca-dev to apt packages required

### DIFF
--- a/documentation/mkdocs/install.md
+++ b/documentation/mkdocs/install.md
@@ -14,7 +14,8 @@ sudo apt-get install -y \
   zbar-tools \
   libzbar0 \
   libzbar-dev \
-  libfuzzy-dev
+  libfuzzy-dev \
+  libcaca-dev
 
 # BEGIN with virtualenv:   
 $SUDO_WWW virtualenv -p python3 /var/www/MISP/venv


### PR DESCRIPTION
I needed to add libcaca-dev to make gtcaca.

## Before
```
misp@server:/usr/local/src/gtcaca/build$ cmake .. && make
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake system name: Linux
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1")
pkg config path:
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- Checking for module 'caca'
--   No package 'caca' found
CMake Error at /usr/share/cmake-3.10/Modules/FindPkgConfig.cmake:415 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.10/Modules/FindPkgConfig.cmake:593 (_pkg_check_modules_internal)
  CMakeLists.txt:69 (pkg_check_modules)


-- Configuring incomplete, errors occurred!
See also "/usr/local/src/gtcaca/build/CMakeFiles/CMakeOutput.log".
```

## After
```
misp@server:/usr/local/src/gtcaca/build$ cmake .. && make
CMake system name: Linux
pkg config path:
-- Checking for module 'caca'
--   Found caca, version 0.99.beta19
libcaca link library: -lcaca
CMake system: Linux
-- Configuring done
-- Generating done
-- Build files have been written to: /usr/local/src/gtcaca/build
```