### PR TITLE
It seems alright to leave the field empty, just have to check empty

### DIFF
--- a/misp_modules/modules/import_mod/csvimport.py
+++ b/misp_modules/modules/import_mod/csvimport.py
@@ -224,7 +224,8 @@ class CsvParser():
 
     @staticmethod
     def __deal_with_tags(attribute):
-        attribute['Tag'] = [{'name': tag.strip()} for tag in attribute['Tag'].split(',')]
+        if 'Tag' in attribute.keys():
+            attribute['Tag'] = [{'name': tag.strip()} for tag in attribute['Tag'].split(',')]
 
     def __get_score(self):
         score = 1 if 'to_ids' in self.header else 0


### PR DESCRIPTION
Running into a bug when importing a CSV with an empty field for tags.  The key "Tags" isn't created on the attributes, but it is checked for.  So, it seems like it is okay to repeat the logic found elsewhere, such that if there are no tags, then the tags field is not processed into separate values.