### PR TITLE
new: Add mmdb lookup expansion module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For more information: [Extending MISP with Python modules](https://www.misp-proj
 * [macvendors](misp_modules/modules/expansion/macvendors.py) - a hover module to retrieve mac vendor information.
 * [MALWAREbazaar](misp_modules/modules/expansion/malwarebazaar.py) - an expansion module to query MALWAREbazaar with some payload.
 * [McAfee MVISION Insights](misp_modules/modules/expansion/mcafee_insights_enrich.py) - an expansion module enrich IOCs with McAfee MVISION Insights.
+* [Mmdb server lookup](misp_modules/modules/expansion/mmdb_lookup.py) - an expansion module to enrich an ip with geolocation information from an mmdb server such as ip.circl.lu.
 * [ocr-enrich](misp_modules/modules/expansion/ocr_enrich.py) - an enrichment module to get OCRized data from images into MISP.
 * [ods-enrich](misp_modules/modules/expansion/ods_enrich.py) - an enrichment module to get text out of OpenOffice spreadsheet document into MISP (using free-text parser).
 * [odt-enrich](misp_modules/modules/expansion/odt_enrich.py) - an enrichment module to get text out of OpenOffice document into MISP (using free-text parser).

--- a/misp_modules/modules/expansion/__init__.py
+++ b/misp_modules/modules/expansion/__init__.py
@@ -18,7 +18,7 @@ __all__ = ['cuckoo_submit', 'vmray_submit', 'bgpranking', 'circl_passivedns', 'c
            'assemblyline_submit', 'assemblyline_query', 'ransomcoindb', 'malwarebazaar',
            'lastline_query', 'lastline_submit', 'sophoslabs_intelix', 'cytomic_orion', 'censys_enrich',
            'trustar_enrich', 'recordedfuture', 'html_to_markdown', 'socialscan', 'passive-ssh',
-           'qintel_qsentry', 'mwdb', 'hashlookup']
+           'qintel_qsentry', 'mwdb', 'hashlookup', 'mmdb_lookup']
 
 
 minimum_required_fields = ('type', 'uuid', 'value')

--- a/misp_modules/modules/expansion/mmdb_lookup.py
+++ b/misp_modules/modules/expansion/mmdb_lookup.py
@@ -1,0 +1,112 @@
+import json
+import requests
+from . import check_input_attribute, standard_error_message
+from pymisp import MISPEvent, MISPObject
+
+misperrors = {'error': 'Error'}
+mispattributes = {'input': ['ip-src', 'ip-src|port', 'ip-dst', 'ip-dst|port'], 'format': 'misp_standard'}
+moduleinfo = {'version': '1', 'author': 'Jeroen Pinoy',
+              'description': "An expansion module to enrich an ip with geolocation information from an mmdb server "
+                             "such as ip.circl.lu",
+              'module-type': ['expansion', 'hover']}
+moduleconfig = ["custom_API"]
+mmdblookup_url = 'https://ip.circl.lu/'
+
+
+class MmdbLookupParser():
+    def __init__(self, attribute, mmdblookupresult, api_url):
+        self.attribute = attribute
+        self.mmdblookupresult = mmdblookupresult
+        self.api_url = api_url
+        self.misp_event = MISPEvent()
+        self.misp_event.add_attribute(**attribute)
+
+    def get_result(self):
+        event = json.loads(self.misp_event.to_json())
+        results = {key: event[key] for key in ('Attribute', 'Object') if (key in event and event[key])}
+        return {'results': results}
+
+    def parse_mmdblookup_information(self):
+        # There is a chance some db's have a hit while others don't so we have to check if entry is empty each time
+        for result_entry in self.mmdblookupresult:
+            if result_entry['country_info']:
+                mmdblookup_object = MISPObject('geolocation')
+                mmdblookup_object.add_attribute('country',
+                                                **{'type': 'text', 'value': result_entry['country_info']['Country']})
+                mmdblookup_object.add_attribute('countrycode',
+                                                **{'type': 'text', 'value': result_entry['country']['iso_code']})
+                mmdblookup_object.add_attribute('latitude',
+                                                **{'type': 'float',
+                                                   'value': result_entry['country_info']['Latitude (average)']})
+                mmdblookup_object.add_attribute('longitude',
+                                                **{'type': 'float',
+                                                   'value': result_entry['country_info']['Longitude (average)']})
+                mmdblookup_object.add_attribute('text',
+                                                **{'type': 'text',
+                                                   'value': 'db_source: {}. build_db: {}. Latitude and longitude are country average.'.format(
+                                                       result_entry['meta']['db_source'],
+                                                       result_entry['meta']['build_db'])})
+                mmdblookup_object.add_reference(self.attribute['uuid'], 'related-to')
+                self.misp_event.add_object(mmdblookup_object)
+
+
+def check_url(url):
+    return "{}/".format(url) if not url.endswith('/') else url
+
+
+def handler(q=False):
+    if q is False:
+        return False
+    request = json.loads(q)
+    if not request.get('attribute') or not check_input_attribute(request['attribute']):
+        return {'error': f'{standard_error_message}, which should contain at least a type, a value and an uuid.'}
+    attribute = request['attribute']
+    if attribute.get('type') == 'ip-src':
+        toquery = attribute['value']
+        pass
+    elif attribute.get('type') == 'ip-src|port':
+        toquery = attribute['value'].split('|')[0]
+        pass
+    elif attribute.get('type') == 'ip-dst':
+        toquery = attribute['value']
+        pass
+    elif attribute.get('type') == 'ip-dst|port':
+        toquery = attribute['value'].split('|')[0]
+        pass
+    else:
+        misperrors['error'] = 'There is no attribute of type ip-src or ip-dst provided as input'
+        return misperrors
+    api_url = check_url(request['config']['custom_API']) if 'config' in request and request['config'].get(
+        'custom_API') else mmdblookup_url
+    r = requests.get("{}/geolookup/{}".format(api_url, toquery))
+    if r.status_code == 200:
+        mmdblookupresult = r.json()
+        if not mmdblookupresult or len(mmdblookupresult) == 0:
+            misperrors['error'] = 'Empty result returned by server'
+            return misperrors
+        # Server might return one or multiple entries which could all be empty, we check if there is at least one
+        # non-empty result below
+        empty_result = True
+        for lookup_result_entry in mmdblookupresult:
+            if lookup_result_entry['country_info']:
+                empty_result = False
+                break
+        if empty_result:
+            misperrors['error'] = 'Empty result returned by server'
+            return misperrors
+    else:
+        misperrors['error'] = 'API not accessible - http status code {} was returned'.format(r.status_code)
+        return misperrors
+    parser = MmdbLookupParser(attribute, mmdblookupresult, api_url)
+    parser.parse_mmdblookup_information()
+    result = parser.get_result()
+    return result
+
+
+def introspection():
+    return mispattributes
+
+
+def version():
+    moduleinfo['config'] = moduleconfig
+    return moduleinfo


### PR DESCRIPTION
Warning: you need one of the latest pymisp releases because countrycode is fairly new in the geolocation object:
https://github.com/MISP/misp-objects/commit/960a03be2267b64841af66cca4fdc3ae192627ed#diff-8bcc19c0ce1cc8ebffed9365f35e3a7cc9f2eb39fde529c2763d4d380d6a317c

I'm not sure when this will be done but maybe updating requirements with a later pymisp version could be a good idea

Tested with following examples (10.0.0.0 for no result case):
![image](https://user-images.githubusercontent.com/9868873/152656182-2f5bda4d-cc5d-4d76-91e8-9e270180cccf.png)

Example result:
![image](https://user-images.githubusercontent.com/9868873/152656362-d73cbcbb-55aa-40c9-ab80-9b35aad3736c.png)
![image](https://user-images.githubusercontent.com/9868873/152656091-54ca311e-6c8f-46d5-a73d-0f7ff7d506ce.png)

I do not have a server that would return multiple results for a query, so I did not test this scenario yet. It should be handled properly however.

Sidenote : Enriching multiple IPs that lead to same object result actually do not create duplicate objects, a reference is just added in that case. It looks like this magic was already implemented somehow.
![image](https://user-images.githubusercontent.com/9868873/152656107-8a32c477-0f86-4e43-a98f-3962bd54920d.png)
