### PR TITLE
Quick fix to service file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ sudo -u www-data /var/www/MISP/venv/bin/pip install .
 sudo cp etc/systemd/system/misp-modules.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now misp-modules
+sudo service misp-modules start #or
 /var/www/MISP/venv/bin/misp-modules -l 127.0.0.1 & #to start the modules
 ~~~~
 

--- a/etc/systemd/system/misp-modules.service
+++ b/etc/systemd/system/misp-modules.service
@@ -7,7 +7,7 @@ User=www-data
 Group=www-data
 WorkingDirectory=/usr/local/src/misp-modules
 Environment="PATH=/var/www/MISP/venv/bin"
-ExecStart=/var/www/MISP/venv/bin/misp-modules -l 127.0.0.1 -s
+ExecStart=/var/www/MISP/venv/bin/misp-modules -l 127.0.0.1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Quick fix to service file, Ubuntu doesn't like the -s option and it is not required. Causes the service to stop. Also added a instruction to start the service in the readme or start modules via the command-line. 