### PR TITLE
fix(REQUIREMENTS): bump `vt-py` to `0.17.1` due to `0.17.0` is no longer exists

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -168,7 +168,7 @@ urlarchiver==0.2
 urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 validators==0.14.0
 vt-graph-api==2.2.0
-vt-py==0.17.0
+vt-py==0.17.1
 vulners==2.0.4
 wand==0.6.10
 websocket-client==1.4.1 ; python_version >= '3.7'


### PR DESCRIPTION
Fixes https://github.com/MISP/misp-modules/issues/584