### PR TITLE
new: add sigmf module to expand a sigmf recording object template

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -71,6 +71,7 @@ maclookup==1.0.3
 markdown-it-py==2.2.0 ; python_version >= '3.7'
 markdownify==0.5.3
 markupsafe==2.1.2 ; python_version >= '3.7'
+matplotlib==3.7.2
 mattermostdriver==7.3.2
 maxminddb==2.3.0 ; python_version >= '3.7'
 mdurl==0.1.2 ; python_version >= '3.7'
@@ -146,6 +147,7 @@ secretstorage==3.3.3 ; sys_platform == 'linux'
 setuptools==67.7.2 ; python_version >= '3.7'
 shodan==1.29.1
 sigmatools==0.19.1
+sigmf==1.1.1
 simplejson==3.19.1 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.3.0 ; python_version >= '3.7'

--- a/misp_modules/modules/expansion/sigmf-expand.py
+++ b/misp_modules/modules/expansion/sigmf-expand.py
@@ -142,8 +142,6 @@ def handler(q=False):
 
     event = MISPEvent()
     expanded_sigmf = MISPObject('sigmf-expanded-recording')
-    logging.error(expanded_sigmf.to_json())
-    logging.error(pymisp.__file__)
 
     if 'core:author' in sigmf_meta['global']:
         expanded_sigmf.add_attribute(

--- a/misp_modules/modules/expansion/sigmf-expand.py
+++ b/misp_modules/modules/expansion/sigmf-expand.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import base64
+import numpy as np
+import matplotlib.pyplot as plt
+import io
 import json
 import tempfile
 import logging
 import sys
 from pymisp import MISPObject, MISPEvent
 from sigmf import SigMFFile
+import pymisp
 
 log = logging.getLogger("sigmf-expand")
 log.setLevel(logging.DEBUG)
@@ -24,6 +28,71 @@ mispattributes = {'input': ['sigmf-recording'], 'output': [
 moduleinfo = {'version': '0.1', 'author': 'Luciano Righetti',
               'description': 'Expand a SigMF Recording object into a SigMF Expanded Recording object.',
               'module-type': ['expansion']}
+
+
+def generate_plots(recording, meta_filename):
+    # FFT plot
+    filename = meta_filename.replace('.sigmf-data', '')
+    # snippet from https://gist.github.com/daniestevez/0d519fd4044f3b9f44e170fd619fbb40
+    NFFT = 2048
+    N = NFFT * 4096
+    fs = recording.get_global_info()['core:sample_rate']
+    x = np.fromfile(recording.data_file, 'int16', count=2*N)
+    x = x[::2] + 1j * x[1::2]
+
+    # f = np.fft.fftshift(np.average(
+    #     np.abs(np.fft.fft(x.reshape(-1, NFFT)))**2, axis=0))
+    # freq = np.fft.fftshift(np.fft.fftfreq(NFFT, 1/fs))
+
+    # plt.figure(figsize=(10, 4))
+    # plt.plot(1e-6 * freq, 10*np.log10(f))
+    # plt.title(filename)
+    # plt.ylabel('PSD (dB)')
+    # plt.xlabel('Baseband frequency (MHz)')
+    # fft_buff = io.BytesIO()
+    # plt.savefig(fft_buff, format='png')
+    # fft_buff.seek(0)
+    # fft_png = base64.b64encode(fft_buff.read()).decode('utf-8')
+
+    # fft_attr = {
+    #     'type': 'attachment',
+    #     'value': filename + '-fft.png',
+    #     'data': fft_png,
+    #     'comment': 'FFT plot of the recording'
+    # }
+
+    # Waterfall plot
+    # snippet from https://pysdr.org/content/frequency_domain.html#fast-fourier-transform-fft
+    fft_size = 1024
+    # // is an integer division which rounds down
+    num_rows = len(x) // fft_size
+    spectrogram = np.zeros((num_rows, fft_size))
+    for i in range(num_rows):
+        spectrogram[i, :] = 10 * \
+            np.log10(np.abs(np.fft.fftshift(
+                np.fft.fft(x[i*fft_size:(i+1)*fft_size])))**2)
+
+    plt.figure(figsize=(10, 4))
+    plt.title(filename)
+    plt.imshow(spectrogram, aspect='auto', extent=[
+               fs/-2/1e6, fs/2/1e6, 0, len(x)/fs])
+    plt.xlabel("Frequency [MHz]")
+    plt.ylabel("Time [ms]")
+    plt.savefig(filename + '-spectrogram.png')
+    waterfall_buff = io.BytesIO()
+    plt.savefig(waterfall_buff, format='png')
+    waterfall_buff.seek(0)
+    waterfall_png = base64.b64encode(waterfall_buff.read()).decode('utf-8')
+
+    waterfall_attr = {
+        'type': 'attachment',
+        'value': filename + '-waterfall.png',
+        'data': waterfall_png,
+        'comment': 'Waterfall plot of the recording'
+    }
+
+    # return [fft_attr, waterfall_attr]
+    return [{'relation': 'waterfall-plot', 'attribute': waterfall_attr}]
 
 
 def handler(q=False):
@@ -73,6 +142,8 @@ def handler(q=False):
 
     event = MISPEvent()
     expanded_sigmf = MISPObject('sigmf-expanded-recording')
+    logging.error(expanded_sigmf.to_json())
+    logging.error(pymisp.__file__)
 
     if 'core:author' in sigmf_meta['global']:
         expanded_sigmf.add_attribute(
@@ -102,11 +173,19 @@ def handler(q=False):
         expanded_sigmf.add_attribute(
             'version', **{'type': 'text', 'value': sigmf_meta['global']['core:version']})
 
-    # TODO: geolocation (GeoJSON)
-
     # add reference to original SigMF Recording object
     expanded_sigmf.add_reference(object['uuid'], "expands")
-    
+
+    # add FFT and waterfall plot
+    try:
+        plots = generate_plots(recording, sigmf_data_attr['value'])
+    except Exception as e:
+        logging.exception(e)
+        return {"error": "Could not generate plots"}
+
+    for plot in plots:
+        expanded_sigmf.add_attribute(plot['relation'], **plot['attribute'])
+
     event.add_object(expanded_sigmf)
     event = json.loads(event.to_json())
 

--- a/misp_modules/modules/expansion/sigmf-expand.py
+++ b/misp_modules/modules/expansion/sigmf-expand.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+import base64
+import json
+import tempfile
+import logging
+import sys
+from pymisp import MISPObject, MISPEvent
+from sigmf import SigMFFile
+
+log = logging.getLogger("sigmf-expand")
+log.setLevel(logging.DEBUG)
+sh = logging.StreamHandler(sys.stdout)
+sh.setLevel(logging.DEBUG)
+fmt = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+sh.setFormatter(fmt)
+log.addHandler(sh)
+
+misperrors = {'error': 'Error'}
+mispattributes = {'input': ['sigmf-recording'], 'output': [
+    'MISP objects'], 'format': 'misp_standard'}
+moduleinfo = {'version': '0.1', 'author': 'Luciano Righetti',
+              'description': 'Expand a SigMF Recording object into a SigMF Expanded Recording object.',
+              'module-type': ['expansion']}
+
+
+def handler(q=False):
+    request = json.loads(q)
+    object = request.get("object")
+    if not object:
+        return {"error": "No object provided"}
+
+    if 'Attribute' not in object:
+        return {"error": "Empty Attribute list"}
+
+    for attribute in object['Attribute']:
+        if attribute['object_relation'] == 'SigMF-data':
+            sigmf_data_attr = attribute
+
+        if attribute['object_relation'] == 'SigMF-meta':
+            sigmf_meta_attr = attribute
+
+    if sigmf_meta_attr is None:
+        return {"error": "No SigMF-data attribute"}
+
+    if sigmf_data_attr is None:
+        return {"error": "No SigMF-meta attribute"}
+
+    try:
+        sigmf_meta = base64.b64decode(sigmf_meta_attr['data']).decode('utf-8')
+        sigmf_meta = json.loads(sigmf_meta)
+    except Exception as e:
+        logging.exception(e)
+        return {"error": "Provided .sigmf-meta is not a valid JSON string"}
+
+    # write temp data file to disk
+    sigmf_data_file = tempfile.NamedTemporaryFile(suffix='.sigmf-data')
+    sigmf_data_bin = base64.b64decode(sigmf_data_attr['data'])
+    with open(sigmf_data_file.name, 'wb') as f:
+        f.write(sigmf_data_bin)
+        f.close()
+
+    try:
+        recording = SigMFFile(
+            metadata=sigmf_meta,
+            data_file=sigmf_data_file.name
+        )
+    except Exception as e:
+        logging.exception(e)
+        return {"error": "Provided .sigmf-meta and .sigmf-data is not a valid SigMF file"}
+
+    event = MISPEvent()
+    expanded_sigmf = MISPObject('sigmf-expanded-recording')
+
+    if 'core:author' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'author', **{'type': 'text', 'value': sigmf_meta['global']['core:author']})
+    if 'core:datatype' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'datatype', **{'type': 'text', 'value': sigmf_meta['global']['core:datatype']})
+    if 'core:description' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'description', **{'type': 'text', 'value': sigmf_meta['global']['core:description']})
+    if 'core:license' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'license', **{'type': 'text', 'value': sigmf_meta['global']['core:license']})
+    if 'core:num_channels' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'num_channels', **{'type': 'counter', 'value': sigmf_meta['global']['core:num_channels']})
+    if 'core:recorder' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'recorder', **{'type': 'text', 'value': sigmf_meta['global']['core:recorder']})
+    if 'core:sample_rate' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'sample_rate', **{'type': 'float', 'value': sigmf_meta['global']['core:sample_rate']})
+    if 'core:sha512' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'sha512', **{'type': 'text', 'value': sigmf_meta['global']['core:sha512']})
+    if 'core:version' in sigmf_meta['global']:
+        expanded_sigmf.add_attribute(
+            'version', **{'type': 'text', 'value': sigmf_meta['global']['core:version']})
+
+    # TODO: geolocation (GeoJSON)
+
+    # add reference to original SigMF Recording object
+    expanded_sigmf.add_reference(object['uuid'], "expands")
+    
+    event.add_object(expanded_sigmf)
+    event = json.loads(event.to_json())
+
+    return {"results": {'Object': event['Object']}}
+
+
+def introspection():
+    return mispattributes
+
+
+def version():
+    return moduleinfo

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -577,13 +577,14 @@ class TestExpansions(unittest.TestCase):
         query_values = ('www.bestwpdesign.com', '79.118.195.239',
                         'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
                         'http://79.118.195.239:1924/.i')
-        results = ('url', 'url', 'virustotal-report', 'virustotal-report')
+        results = ('url', 'url', 'file', 'virustotal-report')
         for query_type, query_value, result in zip(query_types[:2], query_values[:2], results[:2]):
             query = {"module": "urlhaus",
                      "attribute": {"type": query_type,
                                    "value": query_value,
                                    "uuid": "ea89a33b-4ab7-4515-9f02-922a0bee333d"}}
             response = self.misp_modules_post(query)
+            print(response.json())
             self.assertEqual(self.get_attribute(response), result)
         for query_type, query_value, result in zip(query_types[2:], query_values[2:], results[2:]):
             query = {"module": "urlhaus",
@@ -591,6 +592,7 @@ class TestExpansions(unittest.TestCase):
                                    "value": query_value,
                                    "uuid": "ea89a33b-4ab7-4515-9f02-922a0bee333d"}}
             response = self.misp_modules_post(query)
+            print(response.json())
             self.assertEqual(self.get_object(response), result)
 
     def test_urlscan(self):


### PR DESCRIPTION
* Add basic SigMF module to parse a SigMF recording and expand it.
* Supports extracting a SigMF Archive into a SigMF Recording.
* Add waterfall plot when expanding a SigMF Recording

![image](https://github.com/MISP/misp-modules/assets/1659902/b0b38ca8-9ec7-4851-b162-c94ea4733b8b)


## TODO
- [x] SigMF Recording ->  Expanded SigMF recording
- [x] SigMF Archive ->   SigMF recording
- [ ] Annotations
- [ ] Captures
- [ ] Location (GeoJSON)

### SigMF file formats

- [x] SigMF Recording (.sigmf-meta + sigmf-data)
- [x] SigMF Archive 
- [ ] SigMF Collection

### SigMF extensions
- [ ]  ADSB
- [ ] Antenna
- [ ] Signal
- [ ] Capture Details
- [ ] Spatial
- [ ] Spatial CRS
- [ ] WIFI

### Enrichment
- [x] Waterfall Plot

Requires https://github.com/MISP/MISP/pull/9187 and https://github.com/MISP/misp-objects/pull/398