### PR TITLE
Update pandas, shorten build/test time for py3.11

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -91,8 +91,8 @@ oletools==0.60.1
 opencv-python==4.7.0.72
 openpyxl==3.1.2
 packaging==23.1 ; python_version >= '3.7'
-pandas==1.3.5
-pandas-ods-reader==0.1.2
+pandas==1.5.3
+pandas-ods-reader==0.1.4
 passivetotal==2.5.9
 pcodedmp==1.2.6
 pdftotext==2.2.2
@@ -130,7 +130,7 @@ python-magic==0.4.27
 python-pptx==0.6.21
 python-socketio[client]==5.8.0 ; python_version >= '3.6'
 python-utils==3.5.2 ; python_version >= '3.7'
-pytz==2019.3
+pytz==2023.3
 pytz-deprecation-shim==0.1.0.post0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pyyaml==6.0 ; python_version >= '3.6'
 pyzbar==0.1.9


### PR DESCRIPTION
Update pandas to avoid a very time consuming build instead of just using a wheel - looking at pandas breaking changes this shouldn't affect us due to this essentially only being used to do excel reads.