### PR TITLE
[VirusTotal Collections] Fix the export url

### DIFF
--- a/misp_modules/modules/export_mod/virustotal_collections.py
+++ b/misp_modules/modules/export_mod/virustotal_collections.py
@@ -75,8 +75,8 @@ def create_collection(api_key, event_data):
   response_data = response.json()
 
   if response.status_code == 200:
-    link = response_data['data']['links']['self']
-    return f'{uuid}: {link}'
+    col_id = response_data['data']['id']
+    return f'{uuid}: https://www.virustotal.com/gui/collection/{col_id}/iocs'
 
   error = response_data['error']['message']
   if response.status_code == 400:


### PR DESCRIPTION
Using currently the Collection itself API url (https://www.virustotal.com/api/v3/collections/f9dd8c4...) which is not useful for the users.