### PR TITLE
Fix regression in Virustotal modules

### DIFF
--- a/misp_modules/modules/expansion/virustotal.py
+++ b/misp_modules/modules/expansion/virustotal.py
@@ -153,11 +153,11 @@ class VirusTotalParser:
             ('contacted_domains', 'communicates-with'),
             ('contacted_ips', 'communicates-with')
         ]:
-            files_iterator = self.client.iterator(f'/files/{file_report.id}/{relationship_name}', limit=self.limit)
-            for file in files_iterator:
-                file_object = self.create_misp_object(file)
-                file_object.add_reference(file_object.uuid, misp_name)
-                self.misp_event.add_object(**file_object)
+            related_files_iterator = self.client.iterator(f'/files/{file_report.id}/{relationship_name}', limit=self.limit)
+            for related_file in related_files_iterator:
+                related_file_object = self.create_misp_object(related_file)
+                related_file_object.add_reference(file_object.uuid, misp_name)
+                self.misp_event.add_object(**related_file_object)
 
         self.misp_event.add_object(**file_object)
         return file_object.uuid

--- a/misp_modules/modules/expansion/virustotal_public.py
+++ b/misp_modules/modules/expansion/virustotal_public.py
@@ -138,11 +138,11 @@ class VirusTotalParser:
             ('contacted_domains', 'communicates-with'),
             ('contacted_ips', 'communicates-with')
         ]:
-            files_iterator = self.client.iterator(f'/files/{file_report.id}/{relationship_name}', limit=self.limit)
-            for file in files_iterator:
-                file_object = self.create_misp_object(file)
-                file_object.add_reference(file_object.uuid, misp_name)
-                self.misp_event.add_object(**file_object)
+            related_files_iterator = self.client.iterator(f'/files/{file_report.id}/{relationship_name}', limit=self.limit)
+            for related_file in related_files_iterator:
+                related_file_object = self.create_misp_object(related_file)
+                related_file_object.add_reference(file_object.uuid, misp_name)
+                self.misp_event.add_object(**related_file_object)
 
         self.misp_event.add_object(**file_object)
         return file_object.uuid


### PR DESCRIPTION
Since commit `d08bb5c3`, the initial "file" object created by `create_misp_object` is overwritten by the subsequent enrichment logic which pulls relationship data, since they use the same variable name (`file_object`).  This precludes data such as hashes, etc. from being returned as part of the enrichment process, and also creates self-references in the related files objects which are created.

This patch renames `files_iterator` and the associated variables declared in the subsequent for loop to `related_files_iterator`, `related_file_object`, etc. to prevent the original contents of `file_object` from being dropped.
