### PR TITLE
Fix 'Object' object has no attribute 'url' in virustotal

### DIFF
--- a/misp_modules/modules/expansion/virustotal.py
+++ b/misp_modules/modules/expansion/virustotal.py
@@ -84,7 +84,7 @@ class VirusTotalParser:
             misp_object.add_attribute('ip', type='ip-dst', value=report.id)
         elif report.type == 'url':
             misp_object = MISPObject('url')
-            misp_object.add_attribute('url', type='url', value=report.url)
+            misp_object.add_attribute('url', type='url', value=report.id)
         misp_object.add_reference(vt_uuid, 'analyzed-with')
         return misp_object
 

--- a/misp_modules/modules/expansion/virustotal_public.py
+++ b/misp_modules/modules/expansion/virustotal_public.py
@@ -80,7 +80,7 @@ class VirusTotalParser:
             misp_object.add_attribute('ip', type='ip-dst', value=report.id)
         elif report.type == 'url':
             misp_object = MISPObject('url')
-            misp_object.add_attribute('url', type='url', value=report.url)
+            misp_object.add_attribute('url', type='url', value=report.id)
         misp_object.add_reference(vt_uuid, 'analyzed-with')
         return misp_object
 


### PR DESCRIPTION
Fix

File "/var/www/MISP/venv/lib/python3.8/site-packages/misp_modules/__init__.py", line 210, in run_request
    response = module.handler(q=json_payload)
  File "/var/www/MISP/venv/lib/python3.8/site-packages/misp_modules/modules/expansion/virustotal_public.py", line 248, in handler
    parser.query_api(attribute)
  File "/var/www/MISP/venv/lib/python3.8/site-packages/misp_modules/modules/expansion/virustotal_public.py", line 46, in query_api
    self.input_types_mapping[self.attribute.type](self.attribute.value)
  File "/var/www/MISP/venv/lib/python3.8/site-packages/misp_modules/modules/expansion/virustotal_public.py", line 143, in parse_hash
    related_file_object = self.create_misp_object(related_file)
  File "/var/www/MISP/venv/lib/python3.8/site-packages/misp_modules/modules/expansion/virustotal_public.py", line 83, in create_misp_object
    misp_object.add_attribute('Url', type='url', value=report.url)
  File "/var/www/MISP/venv/lib/python3.8/site-packages/vt/object.py", line 160, in __getattribute__
    value = super().__getattribute__(attr)
AttributeError: 'Object' object has no attribute 'url'