### PR TITLE
fix: do not use single quotes in systemd service unit execStart

### DIFF
--- a/documentation/mkdocs/install.md
+++ b/documentation/mkdocs/install.md
@@ -57,7 +57,7 @@ Description=MISP modules
 Type=simple
 User=apache
 Group=apache
-ExecStart='/path/to/venv/bin/misp-modules -l 127.0.0.1 -s'
+ExecStart=/path/to/venv/bin/misp-modules -l 127.0.0.1 -s
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
With the single quotes included, the service didn't start properly for me.