### PR TITLE
[Bug] Added asyncio due to virustotal_public module issue

### DIFF
--- a/misp_modules/modules/expansion/virustotal_public.py
+++ b/misp_modules/modules/expansion/virustotal_public.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 from urllib.parse import urlparse
 
 import vt
@@ -284,6 +285,11 @@ def parse_error(status_code: int) -> str:
 def handler(q=False):
     if q is False:
         return False
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    
     request = json.loads(q)
     if not request.get("config") or not request["config"].get("apikey"):
         misperrors["error"] = "A VirusTotal api key is required for this module."


### PR DESCRIPTION
Hi,

I've encountered the following issue when using the virustotal_public module:

```
  File "/home/misp-modules/.local/lib/python3.11/site-packages/misp_modules/__init__.py", line 223, in post
    response = yield tornado.gen.with_timeout(timeout, future)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/tornado/gen.py", line 766, in run
    value = future.result()
            ^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/misp_modules/__init__.py", line 210, in run_request
    response = module.handler(q=json_payload)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/misp_modules/modules/expansion/virustotal_public.py", line 242, in handler
    client = vt.Client(request['config']['apikey'],
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/vt/client.py", line 241, in __init__
    self._connector = aiohttp.TCPConnector(ssl=self._verify_ssl)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/aiohttp/connector.py", line 776, in __init__
    super().__init__(
  File "/home/misp-modules/.local/lib/python3.11/site-packages/aiohttp/connector.py", line 232, in __init__
    loop = get_running_loop(loop)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/misp-modules/.local/lib/python3.11/site-packages/aiohttp/helpers.py", line 300, in get_running_loop
    loop = asyncio.get_event_loop()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/asyncio/events.py", line 681, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'ThreadPoolExecutor-0_0'.
```
The issue seems to stem from `vt.Client` which runs asynchronously causing the misp virustotal_public module to fail as there is no event loop in the thread. In my current environment, I've added the following inside the virustotal_public handler as a temporary fix:
```
    import asyncio
    try:
        asyncio.get_running_loop()
    except RuntimeError:
        asyncio.set_event_loop(asyncio.new_event_loop())
```

Ref: https://github.com/MISP/misp-modules/issues/726