### PR TITLE
Remove RansomLook API key requirement

### DIFF
--- a/misp_modules/modules/expansion/ransomlook.py
+++ b/misp_modules/modules/expansion/ransomlook.py
@@ -56,7 +56,7 @@ moduleinfo = {
     "module-type": ["expansion", "hover"],
     "name": "RansomLook Lookup",
     "logo": "",
-    "requirements": ["A RansomLook API key."],
+    "requirements": ["No API key required."],
     "features": (
         "The module accepts any MISP attribute value, including text and free-text attributes, and searches across"
         " RansomLook posts using the /api/search endpoint. Matching posts are converted to the MISP"
@@ -70,7 +70,7 @@ moduleinfo = {
     "input": "Any MISP attribute value to search in RansomLook posts.",
     "output": f"RansomLook hits represented as {_OBJECT_NAME} MISP objects.",
 }
-moduleconfig = ["api-key"]
+moduleconfig = []
 api_url = "https://www.ransomlook.io/api"
 
 _OBJECT_MAPPING = {
@@ -165,14 +165,12 @@ def handler(q=False):
     if q is False:
         return False
     request = json.loads(q)
-    if not request.get("config") or not request["config"].get("api-key"):
-        return {"error": "A RansomLook API key is required."}
     if not request.get("attribute") or not check_input_attribute(request["attribute"]):
         return {"error": f"{standard_error_message}, which should contain at least a type, a value and an UUID."}
 
     attribute = request["attribute"]
     query = attribute["value"]
-    headers = {"Authorization": request["config"]["api-key"], "User-Agent": "misp-modules"}
+    headers = {"User-Agent": "misp-modules"}
     try:
         response = requests.get(f"{api_url}/search", params={"query": query}, headers=headers, timeout=30)
         response.raise_for_status()

--- a/tests/test_ransomlook.py
+++ b/tests/test_ransomlook.py
@@ -19,7 +19,7 @@ class MockResponse:
 
 def test_ransomlook_search_returns_ransomware_group_post_object():
     attribute = {"type": "text", "value": "Acme Corporation", "uuid": "5b582d80-7a7e-4b6a-9f22-77656e72bb3b"}
-    query = {"module": "ransomlook", "attribute": attribute, "config": {"api-key": "test-key"}}
+    query = {"module": "ransomlook", "attribute": attribute, "config": {}}
     payload = [
         {
             "group_name": "lockbit",
@@ -39,7 +39,7 @@ def test_ransomlook_search_returns_ransomware_group_post_object():
     mocked_get.assert_called_once_with(
         "https://www.ransomlook.io/api/search",
         params={"query": "Acme Corporation"},
-        headers={"Authorization": "test-key", "User-Agent": "misp-modules"},
+        headers={"User-Agent": "misp-modules"},
         timeout=30,
     )
     assert "Object" in result["results"]
@@ -54,11 +54,6 @@ def test_ransomlook_search_returns_ransomware_group_post_object():
     assert relations["website"] == "https://acme.example"
 
 
-def test_ransomlook_requires_api_key():
-    query = {"module": "ransomlook", "attribute": {"type": "text", "value": "Acme", "uuid": "uuid"}, "config": {}}
-    assert ransomlook.handler(json.dumps(query)) == {"error": "A RansomLook API key is required."}
-
-
 def test_ransomlook_reports_http_error():
     response = Mock(payload=None)
     response.status_code = 401
@@ -66,7 +61,7 @@ def test_ransomlook_reports_http_error():
     query = {
         "module": "ransomlook",
         "attribute": {"type": "text", "value": "Acme", "uuid": "uuid"},
-        "config": {"api-key": "bad-key"},
+        "config": {},
     }
 
     with patch.object(ransomlook.requests, "get", return_value=response):


### PR DESCRIPTION
### Motivation
- RansomLook queries do not require authentication, so the module should not force an API key or send an `Authorization` header.

### Description
- Remove `api-key` from `moduleconfig` by setting `moduleconfig = []` in `misp_modules/modules/expansion/ransomlook.py` and update `moduleinfo["requirements"]` to `"No API key required."`.
- Remove the runtime config check that returned an error when `api-key` was missing.
- Stop sending the `Authorization` header; requests now only include `User-Agent: misp-modules` when calling `https://www.ransomlook.io/api/search`.
- Update `tests/test_ransomlook.py` to use an empty `config` and to assert the unauthenticated request behavior, removing the previous test that enforced an API key.

### Testing
- Ran `pytest -q tests/test_ransomlook.py`, and the suite passed: `2 passed`.
- Performed a quick `git diff --check` to ensure no whitespace errors (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd15c77e48324ad1665ab1f546a92)