### PR TITLE
test: assert RansomLook uses q parameter

### DIFF
--- a/tests/test_ransomlook.py
+++ b/tests/test_ransomlook.py
@@ -33,12 +33,15 @@ def test_ransomlook_search_returns_ransomware_group_post_object():
         }
     ]
 
+    expected_search_params = {"q": "Acme Corporation"}
+
     with patch.object(ransomlook.requests, "get", return_value=MockResponse(payload)) as mocked_get:
         result = ransomlook.handler(json.dumps(query))
 
+    assert "query" not in mocked_get.call_args.kwargs["params"]
     mocked_get.assert_called_once_with(
         "https://www.ransomlook.io/api/search",
-        params={"q": "Acme Corporation"},
+        params=expected_search_params,
         headers={"User-Agent": "misp-modules"},
         timeout=30,
     )


### PR DESCRIPTION
### Motivation
- The RansomLook API expects the search parameter to be `q` not `query`, so the unit test was updated to reflect the correct parameter and prevent regressions.

### Description
- Update `tests/test_ransomlook.py` to use an explicit `expected_search_params = {"q": <value>}` and add an assertion that the legacy `query` parameter is not sent when calling the RansomLook endpoint.

### Testing
- Ran `pytest -q tests/test_ransomlook.py` and the suite passed with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2023f234d8832495f40ede5d7cf108)