### PR TITLE
Fix SSRF bypass for IPv4-mapped IPv6 in HTML-to-Markdown expansion

### DIFF
--- a/misp_modules/modules/expansion/html_to_markdown.py
+++ b/misp_modules/modules/expansion/html_to_markdown.py
@@ -37,8 +37,13 @@ BLOCKED_RANGES = [
 ]
 
 
-def _is_ip_blocked(ip_str: str) -> bool:
+def _normalize_ip_address(ip_str: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
     ip = ipaddress.ip_address(ip_str)
+    return ip.ipv4_mapped or ip
+
+
+def _is_ip_blocked(ip_str: str) -> bool:
+    ip = _normalize_ip_address(ip_str)
     return any(ip in net for net in BLOCKED_RANGES)
 
 
@@ -52,7 +57,7 @@ def _hostname_resolves_to_blocked_ip(hostname: str) -> bool:
 
 def is_safe_url(url: str) -> bool:
     parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
         return False
     try:
         return not _is_ip_blocked(parsed.hostname)

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from misp_modules.modules.expansion.html_to_markdown import is_safe_url
+
+
+class TestHtmlToMarkdownUrlSafety(unittest.TestCase):
+
+    def test_blocks_ipv4_mapped_ipv6_literals_for_blocked_ipv4_ranges(self):
+        blocked_urls = (
+            "http://[::ffff:127.0.0.1]/",
+            "http://[::ffff:10.0.0.1]/",
+            "http://[::ffff:172.16.0.1]/",
+            "http://[::ffff:192.168.0.1]/",
+            "http://[::ffff:169.254.169.254]/",
+        )
+
+        for url in blocked_urls:
+            with self.subTest(url=url):
+                self.assertFalse(is_safe_url(url))
+
+    def test_allows_public_ipv4_mapped_ipv6_literal(self):
+        self.assertTrue(is_safe_url("http://[::ffff:93.184.216.34]/"))
+
+    def test_blocks_hostnames_resolving_to_ipv4_mapped_blocked_addresses(self):
+        with patch(
+            "misp_modules.modules.expansion.html_to_markdown.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("::ffff:127.0.0.1", 0, 0, 0))],
+        ):
+            self.assertFalse(is_safe_url("http://example.test/"))
+
+    def test_rejects_url_without_hostname(self):
+        self.assertFalse(is_safe_url("http:///missing-host"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent SSRF bypass where IPv4-mapped IPv6 literals (e.g. `::ffff:127.0.0.1`) were not normalized and therefore escaped existing IPv4 blocklist checks.  
- Harden URL validation to reject HTTP(S) URLs that lack a hostname as a fail-closed behavior before DNS or literal IP checks.  

### Description
- Add a `_normalize_ip_address` helper that converts IPv4-mapped IPv6 addresses to their underlying IPv4 address and return a proper `ipaddress` object.  
- Update `_is_ip_blocked` to use `_normalize_ip_address` so mapped IPv4-in-IPv6 literals are checked against `BLOCKED_RANGES`.  
- Make `is_safe_url` reject URLs without a hostname by checking `parsed.hostname` in addition to scheme validation.  
- Add a regression test file `tests/test_html_to_markdown.py` covering mapped IPv6 literals, public mapped literals, DNS responses returning mapped addresses, and hostless URLs.  
- Modified file: `misp_modules/modules/expansion/html_to_markdown.py`; added file: `tests/test_html_to_markdown.py`.  

### Testing
- Compiled the modified files with `python -m compileall -q misp_modules/modules/expansion/html_to_markdown.py tests/test_html_to_markdown.py` and then ran `python -m unittest tests.test_html_to_markdown`.  
- Test run: 4 tests executed and all passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53911a34b483248a0a0692431aa569)