### PR TITLE
Preserve bracketed prefixes when stripping email subject markers

### DIFF
--- a/misp_modules/modules/import_mod/email_import.py
+++ b/misp_modules/modules/import_mod/email_import.py
@@ -191,7 +191,6 @@ def dict_handler(request: dict):
 
 SUBJECT_MARKER_RE = re.compile(r"""
     ^\s*
-    (?:(?:\[[^\]]+\]\s*)*)
     (?:
         (?:re|fw|fwd|wg|aw|sv|tr|rv|vs)
         (?:\[\d+\])?

--- a/tests/test_email_import_subject_markers.py
+++ b/tests/test_email_import_subject_markers.py
@@ -1,0 +1,31 @@
+import sys
+from types import ModuleType
+
+
+def load_remove_common_subject_markers():
+    pymisp = ModuleType("pymisp")
+    tools = ModuleType("pymisp.tools")
+    tools.EMailObject = object
+    tools.URLObject = object
+    tools.make_binary_objects = lambda *args, **kwargs: None
+    sys.modules.setdefault("pymisp", pymisp)
+    sys.modules.setdefault("pymisp.tools", tools)
+
+    from misp_modules.modules.import_mod.email_import import remove_common_subject_markers
+
+    return remove_common_subject_markers
+
+
+def test_remove_common_subject_markers_preserves_meaningful_bracketed_prefixes():
+    remove_common_subject_markers = load_remove_common_subject_markers()
+
+    assert remove_common_subject_markers("[CASE-123] RE: malware") == "[CASE-123] RE: malware"
+    assert remove_common_subject_markers("[TLP:AMBER] RE: incident") == "[TLP:AMBER] RE: incident"
+
+
+def test_remove_common_subject_markers_strips_leading_reply_forward_markers():
+    remove_common_subject_markers = load_remove_common_subject_markers()
+
+    assert remove_common_subject_markers("RE: malware") == "malware"
+    assert remove_common_subject_markers(" Fwd: RE: malware") == "malware"
+    assert remove_common_subject_markers("AW[2]: WG: incident") == "incident"


### PR DESCRIPTION
### Motivation
- The subject-marker regex was consuming arbitrary leading bracketed prefixes (e.g. `[CASE-123]`, `[TLP:AMBER]`) when a reply/forward marker followed, losing analyst-relevant context.
- The intent is to strip only common reply/forward markers (like `RE:`, `Fwd:` and indexed variants) while preserving meaningful bracketed metadata.

### Description
- Restrict the subject-strip pattern in `misp_modules/modules/import_mod/email_import.py` by removing the leading `(?:\[[^\]]+\]\s*)*` subpattern so the regex only matches the actual reply/forward marker sequence (`SUBJECT_MARKER_RE`).
- Keep support for common tokens and indexed variants (e.g. `RE`, `FW`, `AW[2]`) and repeated stripping via `remove_common_subject_markers` unchanged.
- Add regression tests in `tests/test_email_import_subject_markers.py` that mock `pymisp.tools` to import `remove_common_subject_markers` and assert preservation of bracketed prefixes and correct stripping of reply/forward markers.

### Testing
- Ran `pytest tests/test_email_import_subject_markers.py -q`, which executed the added tests and reported `2 passed`.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5402a1f1808324b2bc09cac7b6a17d)