### PR TITLE
Fix IPv4 URL safety normalization

### DIFF
--- a/misp_modules/modules/expansion/html_to_markdown.py
+++ b/misp_modules/modules/expansion/html_to_markdown.py
@@ -39,7 +39,7 @@ BLOCKED_RANGES = [
 
 def _normalize_ip_address(ip_str: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
     ip = ipaddress.ip_address(ip_str)
-    return ip.ipv4_mapped or ip
+    return getattr(ip, "ipv4_mapped", None) or ip
 
 
 def _is_ip_blocked(ip_str: str) -> bool:

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -25,6 +25,16 @@ class TestHtmlToMarkdownUrlSafety(unittest.TestCase):
     def test_allows_public_ipv4_mapped_ipv6_literal(self):
         self.assertTrue(is_safe_url("http://[::ffff:93.184.216.34]/"))
 
+    def test_allows_public_ipv4_literal(self):
+        self.assertTrue(is_safe_url("http://93.184.216.34/"))
+
+    def test_allows_hostnames_resolving_to_public_ipv4_addresses(self):
+        with patch(
+            "misp_modules.modules.expansion.html_to_markdown.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("93.184.216.34", 0))],
+        ):
+            self.assertTrue(is_safe_url("http://example.test/"))
+
     def test_blocks_hostnames_resolving_to_ipv4_mapped_blocked_addresses(self):
         with patch(
             "misp_modules.modules.expansion.html_to_markdown.socket.getaddrinfo",


### PR DESCRIPTION
### Motivation
- Guard access to `ipv4_mapped` when normalizing parsed host IPs so plain IPv4 literals or hostnames resolving to IPv4 addresses do not raise `AttributeError` and crash URL safety checks.

### Description
- Replace `ip.ipv4_mapped or ip` with `getattr(ip, "ipv4_mapped", None) or ip` in `misp_modules/modules/expansion/html_to_markdown.py` to safely handle `IPv4Address` and `IPv6Address` values and preserve IPv4-mapped IPv6 behavior, and add two regression tests (`test_allows_public_ipv4_literal` and `test_allows_hostnames_resolving_to_public_ipv4_addresses`) to `tests/test_html_to_markdown.py`.

### Testing
- Ran `python -m pytest tests/test_html_to_markdown.py -q` and all tests passed (`6 passed, 5 subtests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54831ae5488325938e38b250ae395a)