### PR TITLE
Skip rate-limited BTC scam check test

### DIFF
--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -166,8 +166,10 @@ class TestExpansions(unittest.TestCase):
         except Exception:
             self.assertTrue(self.get_values(response).startswith("Not a valid BTC address"))
 
-    @unittest.skip("Remote service rate limits requests from CI IPs")
     def test_btc_scam_check(self):
+        if LiveCI:
+            return
+
         query = {"module": "btc_scam_check", "btc": "1ES14c7qLb5CYhLMUekctxLgc1FV2Ti9DA"}
         response = self.misp_modules_post(query)
         self.assertEqual(self.get_values(response), "1es14c7qlb5cyhlmuekctxlgc1fv2ti9da fraudolent bitcoin address")

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -166,6 +166,7 @@ class TestExpansions(unittest.TestCase):
         except Exception:
             self.assertTrue(self.get_values(response).startswith("Not a valid BTC address"))
 
+    @unittest.skip("Remote service rate limits requests from CI IPs")
     def test_btc_scam_check(self):
         query = {"module": "btc_scam_check", "btc": "1ES14c7qLb5CYhLMUekctxLgc1FV2Ti9DA"}
         response = self.misp_modules_post(query)


### PR DESCRIPTION
### Motivation
- The `btc_scam_check` integration test intermittently fails in CI because the external service rate-limits requests from shared CI IP addresses, so it should not be mandatory for the full test-suite run.

### Description
- Add `@unittest.skip("Remote service rate limits requests from CI IPs")` above the `test_btc_scam_check` test in `tests/test_expansions.py` to mark the test as skipped while keeping it available for manual execution.

### Testing
- Ran `python -m unittest tests.test_expansions.TestExpansions.test_btc_scam_check -v` and the test was skipped as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8302cd6de48325afef4c90a32865b6)