### PR TITLE
scanmalware: report a rejected value as rejected, and look up a URL as that URL

### DIFF
--- a/misp_modules/modules/expansion/scanmalware.py
+++ b/misp_modules/modules/expansion/scanmalware.py
@@ -67,6 +67,15 @@ def _query_value(attribute):
     return value, False
 
 
+class InvalidValue(Exception):
+    """The API rejected the value as not being a hostname, IP or URL.
+
+    Kept distinct from an empty answer on purpose: reporting "no results" for an
+    input the service refused tells the analyst we looked and found nothing, when
+    in fact we never asked a valid question.
+    """
+
+
 def _get(api_url, path, params=None):
     """GET a JSON document, or None when the endpoint has nothing to give."""
     try:
@@ -78,10 +87,24 @@ def _get(api_url, path, params=None):
         )
         if response.status_code == 404:
             return None
+        if response.status_code == 422:
+            raise InvalidValue(_validation_detail(response))
         response.raise_for_status()
         return response.json()
     except (requests.exceptions.RequestException, ValueError):
         return None
+
+
+def _validation_detail(response):
+    """The API's own explanation of why a value was rejected."""
+    try:
+        body = response.json()
+    except ValueError:
+        return "the value was rejected by ScanMalware"
+    details = body.get("details")
+    if isinstance(details, list) and details:
+        return str(details[0])
+    return str(body.get("message") or body.get("error") or "the value was rejected by ScanMalware")
 
 
 class ScanMalwareParser:
@@ -140,13 +163,28 @@ class ScanMalwareParser:
             self._add_hosts(hosts.get("subdomains") or [], "ScanMalware: contacted by a browser during a scan")
 
     def parse_url(self, hostname, url_value):
-        """The most recent sandboxed scan of the host, with its verdict."""
-        scans = _get(
+        """The most recent sandboxed scan, of this URL if there is one.
+
+        The exact URL is asked for first. Falling back to any scan of the same
+        host is useful, but a scan of `https://example.com/` is not a verdict on
+        `https://example.com/login`, so the two are labelled differently rather
+        than presented as the same fact.
+        """
+        exact = _get(
             self.api_url,
-            f"/api/v1/domains/{quote(hostname, safe='')}/scans",
-            {"limit": 5, "status": "completed"},
+            "/api/v1/search/smql",
+            {"q": f"url:{url_value}", "limit": 5, "page": 1},
         )
-        rows = scans if isinstance(scans, list) else (scans or {}).get("results") or []
+        rows = (exact or {}).get("results") or []
+        scanned_this_url = bool(rows)
+
+        if not rows:
+            scans = _get(
+                self.api_url,
+                f"/api/v1/domains/{quote(hostname, safe='')}/scans",
+                {"limit": 5, "status": "completed"},
+            )
+            rows = scans if isinstance(scans, list) else (scans or {}).get("results") or []
         if not rows:
             return
 
@@ -157,17 +195,32 @@ class ScanMalwareParser:
 
         result = _get(self.api_url, f"/api/v1/result/{quote(scan_id, safe='')}")
         verdict = ((result or {}).get("security_verdict") or {}).get("verdict")
-        summary = f"ScanMalware scan of {scan.get('url', url_value)}"
+        scanned_url = scan.get("url", url_value)
+        if scanned_this_url:
+            summary = f"ScanMalware scan of {scanned_url}"
+            comment = "ScanMalware: sandbox verdict"
+        else:
+            summary = f"ScanMalware has no scan of {url_value}; nearest scan on the same host: {scanned_url}"
+            comment = "ScanMalware: verdict for another URL on this host, not for the attribute"
         if verdict:
             summary = f"{summary}: {verdict}"
 
-        self._add(type="text", value=summary, comment="ScanMalware: sandbox verdict", disable_correlation=True)
+        self._add(type="text", value=summary, comment=comment, disable_correlation=True)
         self._add(
             type="link",
             value=f"{self.api_url}/result/{scan_id}",
             comment="ScanMalware: full sandboxed report",
             disable_correlation=True,
         )
+
+        matched_on = scan.get("matched_on")
+        if matched_on and not scanned_this_url:
+            self._add(
+                type="text",
+                value=f"ScanMalware matched {scanned_url} on: {', '.join(matched_on)}",
+                comment="ScanMalware: why this scan matched the host",
+                disable_correlation=True,
+            )
 
         for row in (result or {}).get("ip_table") or []:
             if row.get("ip"):
@@ -243,12 +296,15 @@ def handler(q=False):
         max_results = DEFAULT_MAX_RESULTS
 
     parser = ScanMalwareParser(api_url, max_results)
-    if is_ip:
-        parser.parse_ip(query)
-    elif attribute["type"] == "url":
-        parser.parse_url(query, attribute.get("value", ""))
-    else:
-        parser.parse_domain(query)
+    try:
+        if is_ip:
+            parser.parse_ip(query)
+        elif attribute["type"] == "url":
+            parser.parse_url(query, attribute.get("value", ""))
+        else:
+            parser.parse_domain(query)
+    except InvalidValue as error:
+        return {"error": f"ScanMalware rejected this value: {error}"}
     return parser.get_results()
 
 

--- a/tests/test_scanmalware.py
+++ b/tests/test_scanmalware.py
@@ -162,3 +162,89 @@ def test_no_api_key_is_required_or_sent():
 def test_introspection_and_version():
     assert scanmalware.introspection() == scanmalware.mispattributes
     assert scanmalware.version()["config"] == scanmalware.moduleconfig
+
+
+VALIDATION_422 = {
+    "error": "Validation failed",
+    "message": "Invalid request parameters",
+    "details": ["Invalid value for parameter path -> domain: must be a hostname"],
+}
+
+
+def _status_by_path(mapping, default_status=200, default=None):
+    """requests.get replacement that can return a status code per path fragment."""
+
+    def _get(url, params=None, headers=None, timeout=None):
+        for fragment, (payload, status) in mapping.items():
+            if fragment in url:
+                return MockResponse(payload, status)
+        return MockResponse(default if default is not None else {}, default_status)
+
+    return _get
+
+
+def test_a_rejected_value_is_not_reported_as_no_results():
+    """
+    The API answers 422 for a value that is not a hostname. Reporting that as "no
+    results" tells the analyst we looked and found nothing, when we never asked a
+    valid question. MISP allows single-label hostnames, so this is reachable in
+    ordinary use, not only with pasted junk.
+    """
+    with patch.object(
+        scanmalware.requests,
+        "get",
+        _status_by_path({"ct/dns": (VALIDATION_422, 422)}),
+    ):
+        results = scanmalware.handler(_query("localhost", "hostname"))
+
+    assert "error" in results
+    assert "rejected" in results["error"]
+    assert "must be a hostname" in results["error"]
+
+
+def test_a_url_is_looked_up_as_that_url():
+    """A URL attribute must ask about that URL, not merely about its host."""
+    asked = {}
+
+    def _get(url, params=None, headers=None, timeout=None):
+        if "search/smql" in url:
+            asked["q"] = (params or {}).get("q")
+            return MockResponse({"results": [{"scan_id": "abc", "url": "https://example.com/login"}]})
+        if "/result/" in url:
+            return MockResponse({"security_verdict": {"verdict": "malicious"}})
+        return MockResponse({})
+
+    with patch.object(scanmalware.requests, "get", _get):
+        results = scanmalware.handler(_query("https://example.com/login", "url"))
+
+    assert asked["q"] == "url:https://example.com/login"
+    summary = [a["value"] for a in results["results"]["Attribute"] if a["type"] == "text"][0]
+    assert summary.startswith("ScanMalware scan of https://example.com/login")
+    assert "malicious" in summary
+
+
+def test_a_scan_of_another_url_on_the_host_is_labelled_as_such():
+    """
+    Falling back to the host is useful, but a scan of `https://example.com/` is not
+    a verdict on `https://example.com/login`. The distinction has to survive into
+    what the analyst reads.
+    """
+
+    def _get(url, params=None, headers=None, timeout=None):
+        if "search/smql" in url:
+            return MockResponse({"results": []})
+        if "/scans" in url:
+            return MockResponse([{"scan_id": "abc", "url": "https://example.com/", "matched_on": ["final_url"]}])
+        if "/result/" in url:
+            return MockResponse({"security_verdict": {"verdict": "malicious"}})
+        return MockResponse({})
+
+    with patch.object(scanmalware.requests, "get", _get):
+        results = scanmalware.handler(_query("https://example.com/login", "url"))
+
+    texts = [a["value"] for a in results["results"]["Attribute"] if a["type"] == "text"]
+    summary = texts[0]
+    assert "has no scan of https://example.com/login" in summary
+    assert "nearest scan on the same host" in summary
+    # and the reason it matched the host is carried through
+    assert any("matched https://example.com/ on: final_url" in t for t in texts)


### PR DESCRIPTION
Follow-up to #803, which merged this morning. Three fixes, one of them a correctness
bug I found while chasing @adulau's review comment.

**A URL attribute is now looked up as that URL.** The merged module takes the newest
scan of the same *host*, so enriching `https://github.io/` reports the verdict for
`http://cobig99.github.io/microsoft365-en-us-excel/` as though it judged the attribute.
Measured against the live API just now:

| | scan reported for `https://github.io/` |
| --- | --- |
| as merged | `http://cobig99.github.io/microsoft365-en-us-excel/` |
| with this change | `https://github.io/` |

Host-level fallback is still there, because it is often what you want, but it now says
so: *"has no scan of X; nearest scan on the same host: Y"*.

This was only fixable now. The API's `url:` filter used to terminate a field value at
the first `:`, so `url:https://…` silently matched every scan; querying the host was the
workaround. That was reported and fixed server-side on 2026-08-27.

**A rejected value is reported as rejected.** Following @adulau's note, the API now
returns `422` for a value that is not a hostname. The module turned that into "No
ScanMalware results for this attribute", which says we looked and found nothing when no
valid question was asked. A single-label MISP `hostname` attribute reaches this in
ordinary use:

```
hostname: localhost
  error: ScanMalware rejected this value: Invalid value for parameter
         path -> domain: must be a hostname with at least two labels
         (e.g. example.com) or an IP address
```

**Scans matched via a redirect carry the API's new `matched_on` field**, so a scan of
another site that redirects to the queried host is explicable instead of looking like
noise.

**Proof:** 15 tests pass (`pytest tests/test_scanmalware.py`), `flake8` clean with the
project config. The three new tests were each run against a deliberately broken build
first: removing the 422 branch, querying the host instead of the URL, dropping the
distinct fallback label, and dropping `matched_on` each fail the test that covers them
and nothing else. All three paths were also exercised against the live API, not only
mocks.
