### PR TITLE
fix: [passivetotal] recognise SHA1 hashes by their real length

### DIFF
--- a/misp_modules/modules/expansion/passivetotal.py
+++ b/misp_modules/modules/expansion/passivetotal.py
@@ -351,7 +351,7 @@ def process_malware(instance, query):
     for h in content["hashes"]:
         if len(h) == 32:
             hashes["md5"].append(h)
-        elif len(h) == 41:
+        elif len(h) == 40:
             hashes["sha1"].append(h)
         elif len(h) == 64:
             hashes["sha256"].append(h)


### PR DESCRIPTION
`process_malware()` in `misp_modules/modules/expansion/passivetotal.py` classifies hashes by string length:

```python
if len(h) == 32:      # md5
elif len(h) == 41:    # sha1
elif len(h) == 64:    # sha256
```

A hex-encoded SHA1 is **40** characters. Every SHA1 returned by the PassiveTotal malware endpoint therefore matched none of the branches and was silently discarded — `hashes["sha1"]` is always empty, and nothing in the response tells the analyst that values were dropped.

One-character fix: `41` → `40`.

### Verification
- Full suite green against a locally running `misp-modules` server: **161 passed, 4 skipped, 5 subtests passed**.
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/` clean on the changed file.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
