### PR TITLE
[high] fix: [website] commit the transaction when an external tool is deleted

### DIFF
--- a/website/app/external_tools/external_tools_core.py
+++ b/website/app/external_tools/external_tools_core.py
@@ -50,6 +50,7 @@ def delete_tool(tool_id):
     tool = get_tool(tool_id)
     if tool:
         db.session.delete(tool)
+        db.session.commit()
         return True
     return False
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Deleting an external tool never committed, so the tool and its stored API key stayed active.

- **Problem** — `delete_tool()` in `website/app/external_tools/external_tools_core.py` calls `db.session.delete(tool)` but never commits, so the session is discarded at the end of the request and the row survives. The route still reports "Tool deleted", leaving the tool with its stored `url` and `api_key` active for enrichment requests.
- **Fix** — Adds the missing `db.session.commit()`, matching `add_external_tool()` directly above it.
- **Effect** — Deleting an external tool actually removes it and its stored API key.
<!-- /bluf -->

`delete_tool()` in `website/app/external_tools/external_tools_core.py` deletes the row but never commits:

```python
def delete_tool(tool_id):
    tool = get_tool(tool_id)
    if tool:
        db.session.delete(tool)
        return True
```

The session is discarded at the end of the request, so the row survives. The route reports **"Tool deleted"** while the tool — including its stored `url` and `api_key`, which the enrichment path sends as `X-API-KEY` (`website/app/home_core.py:135`) — is still present and still in use.

`add_external_tool()` immediately above already calls `db.session.commit()`; this makes deletion consistent.

### Verification
The `website/` app has no automated test coverage in this repository, so verification is:
- `py_compile` on the changed file;
- the module test suite still green against a locally running `misp-modules` server: **161 passed, 4 skipped, 5 subtests passed**.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

