### PR TITLE
[high] fix(xlsx_enrich): use None for unlimited display.max_colwidth

### DIFF
--- a/misp_modules/modules/expansion/xlsx_enrich.py
+++ b/misp_modules/modules/expansion/xlsx_enrich.py
@@ -43,8 +43,8 @@ def handler(q=False):
 
     xls_content = ""
     xls_file = io.BytesIO(xlsx_array)
-    pandas.set_option("display.max_colwidth", -1)
     try:
+        pandas.set_option("display.max_colwidth", None)
         xls = pandas.read_excel(xls_file)
         xls_content = xls.to_string(max_rows=None)
         print(xls_content)

--- a/tests/test_xlsx_enrich.py
+++ b/tests/test_xlsx_enrich.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import base64
+import io
+import json
+import unittest
+
+import pandas
+
+from misp_modules.modules.expansion.xlsx_enrich import handler
+
+
+def _xlsx_attachment():
+    buffer = io.BytesIO()
+    pandas.DataFrame({"ioc": ["1.2.3.4"]}).to_excel(buffer, index=False)
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+class TestXlsxEnrich(unittest.TestCase):
+
+    def test_handler_extracts_text_from_xlsx(self):
+        query = json.dumps({"attachment": "test.xlsx", "data": _xlsx_attachment()})
+
+        result = handler(query)
+
+        self.assertNotIn("error", result)
+        self.assertIn("1.2.3.4", result["results"][0]["values"])
+
+    def test_handler_sets_unlimited_column_width(self):
+        query = json.dumps({"attachment": "test.xlsx", "data": _xlsx_attachment()})
+
+        handler(query)
+
+        self.assertIsNone(pandas.get_option("display.max_colwidth"))


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `xlsx_enrich` failed every query because modern pandas rejects a `display.max_colwidth` of `-1`.

- **Problem** — `xlsx_enrich.py` called `pandas.set_option("display.max_colwidth", -1)`, which modern pandas rejects with `ValueError`, and the call sat outside the handler's `try` block so nothing caught it. Every query against the module failed before `read_excel()` was reached, returning neither a result nor a MISP error.
- **Fix** — Passes `None`, the current spelling of unlimited width, and moves the call inside the `try` block, with regression tests.
- **Effect** — xlsx attachments are parsed again, and any future pandas breakage surfaces as a normal `misperrors` dict.
<!-- /bluf -->

## Problem

`misp_modules/modules/expansion/xlsx_enrich.py`, line 46 (before this change) called:

```python
pandas.set_option("display.max_colwidth", -1)
```

Modern pandas rejects a negative value for that option and raises
`ValueError: Value must be a nonnegative integer or None` (reproduced with pandas 2.3.3).
Because the call sat *outside* the surrounding `try` block, the exception was not caught by
the module's error handling and propagated out of `handler()`.

Concrete trigger: any query at all against this module — e.g. a `attachment` query with a
valid base64-encoded `.xlsx` in `data`. The first statement after decoding the attachment
raises, so the module never reaches `pandas.read_excel()` and returns no result and no
MISP error dict.

## Fix

- Pass `None` instead of `-1`. `None` is the current pandas spelling of "unlimited column
  width" and preserves the original intent of the code.
- Move the `set_option()` call inside the existing `try` block, so that any future pandas
  change here degrades into the module's normal `misperrors` error dict rather than an
  unhandled exception. This matches how the rest of the pandas work in this handler
  (`read_excel`, `to_string`) is already guarded.

The change is two lines and does not alter the module's output format.

## Testing

Gate command: `poetry run pytest` (the same invocation used by the repo's
`.github/workflows/test-package.yml`).

Result: `106 passed, 5 subtests passed in 89.81s (0:01:29)`.

Regression coverage added in `tests/test_xlsx_enrich.py`:

- `TestXlsxEnrich::test_handler_extracts_text_from_xlsx` — builds an in-memory `.xlsx`
  attachment, runs `handler()`, and asserts the cell contents come back in the freetext
  result. This fails with the old `-1` value.
- `TestXlsxEnrich::test_handler_sets_unlimited_column_width` — asserts
  `display.max_colwidth` ends up as `None`, pinning the intended "unlimited" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

