### PR TITLE
fix(import): skip network sections missing from Cuckoo reports

### DIFF
--- a/misp_modules/modules/import_mod/cuckooimport.py
+++ b/misp_modules/modules/import_mod/cuckooimport.py
@@ -343,7 +343,7 @@ class CuckooParser:
 
     def add_http(self):
         """Add the HTTP requests"""
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         http = network.get("http", [])
         if not http:
             log.info("No HTTP connection found in the report, skipping")
@@ -363,7 +363,7 @@ class CuckooParser:
         Add UDP/TCP traffic
         proto must be one of "tcp", "udp"
         """
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         li_conn = network.get(proto, [])
         if not li_conn:
             log.info(f"No {proto} connection found in the report, skipping")
@@ -394,7 +394,7 @@ class CuckooParser:
 
     def add_dns(self):
         """Add DNS records"""
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         dns = network.get("dns", [])
         if not dns:
             log.info("No DNS connection found in the report, skipping")

--- a/tests/test_cuckooimport.py
+++ b/tests/test_cuckooimport.py
@@ -1,0 +1,22 @@
+from misp_modules.modules.import_mod.cuckooimport import CuckooParser
+
+
+def _parser():
+    parser = CuckooParser({})
+    parser.report = {}
+    return parser
+
+
+def test_add_http_without_network_section():
+    """A report without a "network" section must not raise."""
+    assert _parser().add_http() is False
+
+
+def test_add_network_without_network_section():
+    parser = _parser()
+    assert parser.add_network("tcp") is False
+    assert parser.add_network("udp") is False
+
+
+def test_add_dns_without_network_section():
+    assert _parser().add_dns() is False


### PR DESCRIPTION
## Problem

`CuckooParser.add_http()`, `add_network()` and `add_dns()` in
`misp_modules/modules/import_mod/cuckooimport.py` (lines 346, 366 and 397) read the
report's network section with a list default and then immediately treat the result
as a mapping:

```python
network = self.report.get("network", [])
http = network.get("http", [])
```

Each of the three methods is clearly meant to log "No ... connection found in the
report, skipping" and return `False` when the data is absent. But when a Cuckoo
report has no `"network"` key at all, `.get()` returns the default `[]`, and the
very next line raises:

```
AttributeError: 'list' object has no attribute 'get'
```

Concrete trigger: a Cuckoo JSON report whose top level has no `"network"` section
(for example a static/no-network analysis, or a truncated report). Instead of
skipping the three network sections, the import aborts entirely and no event is
produced.

## Fix

Change the default at all three call sites from `[]` to `{}`. The subsequent
`network.get(...)` then returns the empty list it already expects, so the existing
"no connection found, skipping" branch is taken and the rest of the report is still
imported. This matches the shape actually stored under `"network"` in a Cuckoo
report (a dict keyed by `http` / `tcp` / `udp` / `dns`) and the mapping defaults
used elsewhere in the same parser. No behaviour changes for reports that do have a
network section.

## Testing

Ran the repository test suite (`pytest tests/`): **107 passed, 5 subtests passed in
99.67s (0:01:39)**.

Added `tests/test_cuckooimport.py` with a regression test for this case,
`test_add_http_without_network_section`, plus
`test_add_network_without_network_section` and
`test_add_dns_without_network_section`, each asserting the method returns `False`
rather than raising when the report has no network section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
