### PR TITLE
[medium] fix(crowdstrike_falcon): guard missing body/errors in API response

### DIFF
--- a/misp_modules/modules/expansion/crowdstrike_falcon.py
+++ b/misp_modules/modules/expansion/crowdstrike_falcon.py
@@ -242,7 +242,8 @@ class CSIntelAPI:
         if r.get("status_code") != 200:
             raise Exception("HTTP Error: " + str(r.get("status_code")))
 
-        if len(r.get("body").get("errors")):
-            raise Exception("API Error: " + " | ".join(r.get("body").get("errors")))
+        errors = (r.get("body") or {}).get("errors") or []
+        if errors:
+            raise Exception("API Error: " + " | ".join(errors))
 
         return r.get("body", {})

--- a/tests/test_crowdstrike_falcon.py
+++ b/tests/test_crowdstrike_falcon.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from misp_modules.modules.expansion import crowdstrike_falcon
+
+
+def _api(response):
+    with patch.object(crowdstrike_falcon, "Intel") as mocked_intel:
+        mocked_intel.return_value.query_indicator_entities.return_value = response
+        return crowdstrike_falcon.CSIntelAPI(custid="id", custkey="key")
+
+
+def test_search_indicator_without_body():
+    api = _api({"status_code": 200})
+    assert api.search_indicator("foo") == {}
+
+
+def test_search_indicator_without_errors_key():
+    api = _api({"status_code": 200, "body": {"resources": []}})
+    assert api.search_indicator("foo") == {"resources": []}
+
+
+def test_search_indicator_raises_on_api_errors():
+    api = _api({"status_code": 200, "body": {"errors": ["bad", "worse"]}})
+    with pytest.raises(Exception, match=r"API Error: bad \| worse"):
+        api.search_indicator("foo")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `crowdstrike_falcon` crashed on 200 responses missing `body` or `errors` instead of returning the payload.

- **Problem** — `CSIntelAPI.search_indicator()` in `crowdstrike_falcon.py` validated a 200 response with `len(r.get("body").get("errors"))`, which raises `AttributeError` if `body` is absent and `TypeError` if `errors` is, even though the very next line already tolerates a missing body.
- **Fix** — Resolves the error list defensively as `(r.get("body") or {}).get("errors") or []` and reuses it when raising, with regression tests added.
- **Effect** — The module degrades to returning whatever body the API sent rather than an unrelated traceback.
<!-- /bluf -->

## Problem

`CSIntelAPI.search_indicator()` in `misp_modules/modules/expansion/crowdstrike_falcon.py` (line 245 before this change) validated a successful response with:

```python
if len(r.get("body").get("errors")):
```

That assumes every HTTP 200 payload from the Falcon Intel API contains a `body` dict which in turn contains an `errors` key. Neither is guaranteed:

- A 200 response with no `body` key — e.g. `{"status_code": 200}` — makes `r.get("body")` return `None`, so `.get("errors")` raises `AttributeError: 'NoneType' object has no attribute 'get'`.
- A 200 response whose body has no `errors` key — e.g. `{"status_code": 200, "body": {"resources": []}}` — makes `len(None)` raise `TypeError: object of type 'NoneType' has no len()`.

In both cases the module fails with an unrelated traceback instead of returning the response the caller asked for, which masks the actual API result. The success path on the next line already tolerates a missing body (`return r.get("body", {})`), so the guard is stricter than the code immediately following it.

## Fix

Resolve the error list defensively before testing it, and reuse it when raising:

```python
errors = (r.get("body") or {}).get("errors") or []
if errors:
    raise Exception("API Error: " + " | ".join(errors))
```

This keeps the existing behaviour whenever the API does report errors (same exception type and message format), and otherwise falls through to the existing `return r.get("body", {})` — matching the tolerance that success path already has. It also avoids walking the response dict twice to build the message.

## Testing

- Gate: `poetry run pytest` (the same invocation CI uses) — result: 107 passed, 5 subtests passed in 79.28s (0:01:19).
- Regression coverage added in `tests/test_crowdstrike_falcon.py`:
  - `test_search_indicator_without_body` — 200 response with no `body` key returns `{}` instead of raising `AttributeError`.
  - `test_search_indicator_without_errors_key` — 200 response with a body but no `errors` key returns the body instead of raising `TypeError`.
  - `test_search_indicator_raises_on_api_errors` — a populated `errors` list still raises with the joined message, so the existing behaviour is preserved.

No live Falcon credentials are needed; the tests patch the `Intel` client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

