### PR TITLE
[high] fix(expansion): tolerate missing tags in qintel_qsentry and yeti

### DIFF
--- a/misp_modules/modules/expansion/qintel_qsentry.py
+++ b/misp_modules/modules/expansion/qintel_qsentry.py
@@ -54,7 +54,7 @@ def _return_error(message):
 
 def _make_tags(enriched_attr, result):
 
-    for tag in result["tags"]:
+    for tag in result.get("tags") or []:
         color = TAG_COLOR["suspicious"]
         if tag == "criminal":
             color = TAG_COLOR["malicious"]
@@ -149,7 +149,7 @@ def _format_hover(event, result):
 
     enriched_object = event.get_objects_by_name("Qintel Threat Enrichment")[0]
 
-    tags = ", ".join(result.get("tags"))
+    tags = ", ".join(result.get("tags") or [])
     enriched_object.add_attribute("Tags", type="text", value=tags)
 
     return event

--- a/misp_modules/modules/expansion/yeti.py
+++ b/misp_modules/modules/expansion/yeti.py
@@ -120,7 +120,7 @@ class Yeti:
             logging.error("type not found %s" % obs_to_add["type"])
             return
 
-        for t in obs_to_add["tags"]:
+        for t in obs_to_add.get("tags") or []:
             self.misp_event.add_attribute_tag(t["name"], attr["uuid"])
 
     def __get_object_domain_ip(self, obj_to_add):

--- a/tests/test_qintel_qsentry.py
+++ b/tests/test_qintel_qsentry.py
@@ -1,0 +1,55 @@
+import json
+import sys
+import types
+from unittest.mock import patch
+
+# qintel_helper is an optional third-party dependency of the module and is not
+# installed in the test environment; provide a stub so the module is importable.
+_fake_helper = types.ModuleType("qintel_helper")
+_fake_helper.search_qsentry = lambda *args, **kwargs: {}
+sys.modules.setdefault("qintel_helper", _fake_helper)
+
+from misp_modules.modules.expansion import qintel_qsentry  # noqa: E402
+
+UNTAGGED_PAYLOAD = {
+    "asn": 64500,
+    "asn_name": "example network",
+    "descriptions": ["no threat activity observed"],
+    "last_seen": "2024-01-01T00:00:00Z",
+}
+
+
+def _query(event_id=None):
+    request = {
+        "module": "qintel_qsentry",
+        "attribute": {
+            "type": "ip-src",
+            "value": "1.2.3.4",
+            "uuid": "5b582d80-7a7e-4b6a-9f22-77656e72bb3b",
+        },
+        "config": {"token": "t"},
+    }
+    if event_id is not None:
+        request["event_id"] = event_id
+    return json.dumps(request)
+
+
+def test_qintel_qsentry_handles_result_without_tags():
+    with patch.object(qintel_qsentry, "search_qsentry", return_value=UNTAGGED_PAYLOAD):
+        result = qintel_qsentry.handler(_query(event_id=1))
+
+    assert "error" not in result
+    enriched = [obj for obj in result["results"]["Object"] if obj["name"] == "Qintel Threat Enrichment"][0]
+    enriched_attr = [attr for attr in enriched["Attribute"] if attr["object_relation"] == "enriched-attr"][0]
+    assert enriched_attr.get("Tag", []) == []
+
+
+def test_qintel_qsentry_hover_handles_result_without_tags():
+    with patch.object(qintel_qsentry, "search_qsentry", return_value=UNTAGGED_PAYLOAD):
+        result = qintel_qsentry.handler(_query())
+
+    assert "error" not in result
+    enriched = [obj for obj in result["results"]["Object"] if obj["name"] == "Qintel Threat Enrichment"][0]
+    # pymisp drops attributes with an empty value, so the hover "Tags" attribute
+    # is simply absent; the point is that the hover path no longer raises.
+    assert [attr for attr in enriched["Attribute"] if attr["object_relation"] == "Tags"] == []

--- a/tests/test_yeti.py
+++ b/tests/test_yeti.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from misp_modules.modules.expansion import yeti
+
+
+def _make_client():
+    attribute = {
+        "type": "ip-src",
+        "value": "1.2.3.4",
+        "uuid": "5b582d80-7a7e-4b6a-9f22-77656e72bb3b",
+    }
+    with patch.object(yeti.pyeti, "YetiApi"):
+        return yeti.Yeti("https://yeti.example", "key", attribute)
+
+
+def test_yeti_handles_observable_without_tags():
+    client = _make_client()
+    obs_to_add = {"type": "Domain", "value": "example.com"}
+
+    client._Yeti__get_attribute(obs_to_add, "resolves to")
+
+    values = [attr.value for attr in client.misp_event.attributes]
+    assert "example.com" in values


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Untagged QSentry and YETI results raise out of the handler and fail the whole enrichment request.

- **Problem** — `qintel_qsentry.py` assumes every QSentry result carries a `tags` key, in `_make_tags` and in `_format_hover`, and `yeti.py` does the same in `Yeti.__get_attribute`, so a lookup for an IP with no threat tags raises `KeyError`, or `TypeError` on the hover path, outside the handler's `try`/`except`.
- **Fix** — Read the key as `.get("tags") or []` at all three sites and add regression tests.
- **Effect** — Untagged QSentry and YETI results return their AS and last-seen data instead of failing the enrichment request.
<!-- /bluf -->

## Problem

`misp_modules/modules/expansion/qintel_qsentry.py` assumes every QSentry result carries a `tags` key:

- line 57, in `_make_tags`: `for tag in result["tags"]:`
- line 152, in `_format_hover`: `tags = ", ".join(result.get("tags"))`

A QSentry lookup for an IP with no threat tags returns a result without that key. The first site then raises `KeyError: 'tags'`, and the hover path (used when the request has no `event_id`) raises `TypeError` on `", ".join(None)`. Both calls happen in `handler()` *after* the `try/except` that wraps `search_qsentry(...)`, so nothing catches them and the whole enrichment request fails instead of returning the AS / last-seen data that was retrieved successfully.

`misp_modules/modules/expansion/yeti.py` line 123, in `Yeti.__get_attribute`, has the identical pattern — `for t in obs_to_add["tags"]:` — so an observable returned by a YETI instance without a `tags` key crashes the same way.

## Fix

Use `.get("tags") or []` at all three sites. The tag loops simply do not execute when tags are absent (or `null`), and the hover join yields an empty string, which `add_attribute("Tags", type="text", value="")` handles fine. This matches the defensive `.get(...)` style already used elsewhere in `qintel_qsentry.py` (e.g. `config.get("remote")`, `request.get("event_id")`) and keeps the tagged path byte-for-byte identical.

The `or []` form (rather than `.get("tags", [])`) is deliberate: it also covers a JSON `null` value for the key, not just a missing key.

## Testing

Gate command: `poetry run pytest`

Result: 107 passed, 5 subtests passed in 120.24s (0:02:00)

Regression tests added:

- `tests/test_qintel_qsentry.py::test_qintel_qsentry_handles_result_without_tags`
- `tests/test_qintel_qsentry.py::test_qintel_qsentry_hover_handles_result_without_tags`
- `tests/test_yeti.py::test_yeti_handles_observable_without_tags`

All three fail with `KeyError: 'tags'` when the source change is reverted, and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

