### PR TITLE
[high] fix: [website] initialise the session lookup flag before the search loop

### DIFF
--- a/website/app/home_core.py
+++ b/website/app/home_core.py
@@ -243,6 +243,7 @@ def set_flask_session(current_session, parent_id):
             # If not in current query, current query change for an other one
             if not util_set_flask_session(parent_id, loc_session, current_session):
                 # sess["uuid"]
+                flag = True
                 for q in sess:
                     if isUUID(q) and not q == current_query:
                         loc_session = sess.get(q)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A no-match session lookup raises `UnboundLocalError`, so `/run_modules` returns a 500.

- **Problem** — In `set_flask_session()` in `website/app/home_core.py`, the local `flag` is only assigned inside the loop that searches for a matching session tree, so when nothing matches the trailing `if flag:` raises `UnboundLocalError`.
- **Fix** — Initialise `flag = True` before the loop, so the no-match path still falls through to `create_new_session_tree()`.
- **Effect** — A `POST /run_modules` with `query_as_same` or `query_as_params` no longer returns a 500, and the query session is recreated instead of lost.
<!-- /bluf -->

## The defect

In `set_flask_session()`, `flag` is only assigned when a matching session tree is found:

```python
if not util_set_flask_session(parent_id, loc_session, current_session):
    # sess["uuid"]
    for q in sess:
        if isUUID(q) and not q == current_query:
            loc_session = sess.get(q)
            if "children" not in loc_session:
                loc_session["children"] = list()
            if util_set_flask_session(
                parent_id, loc_session, current_session
            ):
                sess["current_query"] = q
                flag = False
                break
    if flag:
        create_new_session_tree(current_session, parent_id)
```

If the `for q in sess` loop never matches (or `sess` yields no UUID keys), `flag` is never assigned, and `if flag:` raises `UnboundLocalError`.

## Impact

An analyst issuing `POST /run_modules` with `query_as_same` or `query_as_params` hits this no-match/empty-loop path and gets an unhandled `UnboundLocalError`, which surfaces as a 500 response. The session-tree bookkeeping never completes, so the user's query session is silently lost instead of being reattached or recreated.

## The fix

Initialise `flag = True` immediately before the loop. The finding's proposed fix suggested `flag = False`, but the variable's sense is inverted here: it is cleared to `False` only once a matching parent session is found and the loop breaks, and the trailing `if flag:` is what triggers the fallback `create_new_session_tree(...)` call for the no-match case. Initialising to `False` would make that `if flag:` never fire on a no-match path, silently dropping the session instead of falling back to creating a new session tree — the opposite of the intended behaviour. `True` preserves the existing create-a-new-session-tree fallback while eliminating the crash.

### Verification

- `python3 -m py_compile website/app/home_core.py` — clean.
- `website/` has no automated test coverage in this repository, so behavioural verification for this change is limited to the py_compile check above plus confirming the module test suite still passes unrelated to this change: `161 passed, 4 skipped, 5 subtests passed in 152.05s (0:02:32)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

