### PR TITLE
[high] fix: [website] reuse the admin user row instead of inserting it on every login

### DIFF
--- a/website/app/account/account.py
+++ b/website/app/account/account.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, flash, redirect, render_template, request, url_for
-from flask_login import current_user, login_required, login_user, logout_user
+from flask_login import login_required, login_user, logout_user
 
 from app import db
 from app.models import User
@@ -18,11 +18,13 @@ def login():
     form = LoginForm()
     if form.validate_on_submit():
         if form.password.data == str(admin_password()):
-            user = User(
-                email="admin@admin.admin", first_name="admin", last_name="admin"
-            )
-            db.session.add(user)
-            db.session.commit()
+            user = User.query.filter_by(email="admin@admin.admin").first()
+            if user is None:
+                user = User(
+                    email="admin@admin.admin", first_name="admin", last_name="admin"
+                )
+                db.session.add(user)
+                db.session.commit()
             login_user(user, form.remember_me.data)
             flash("You are now logged in. Welcome back!", "success")
             return redirect(request.args.get("next") or "/")
@@ -34,7 +36,6 @@ def login():
 @account_blueprint.route("/logout")
 @login_required
 def logout():
-    User.query.filter_by(id=current_user.id).delete()
     logout_user()
 
     flash("You have been logged out.", "info")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The website admin cannot log back in after the first logout: login 500s on a unique constraint.

- **Problem** — The login view in `website/app/account/account.py` inserts a fresh `User` row with the unique email `admin@admin.admin` on every successful password check, and the matching delete in `logout()` is never committed, so the second login hits the unique constraint and raises `IntegrityError` out of the view.
- **Fix** — Look the user up by email and only insert when absent, and remove the no-op delete from `logout()`.
- **Effect** — An admin can log back into the website UI after the first logout instead of getting a 500.
<!-- /bluf -->

The login view unconditionally inserts a new `User` row on every successful password check, while the email column is unique:

```python
if form.password.data == str(admin_password()):
    user = User(
        email="admin@admin.admin", first_name="admin", last_name="admin"
    )
    db.session.add(user)
    db.session.commit()
    login_user(user, form.remember_me.data)
```

`logout()` looked like it cleaned the row up, but the delete was never committed and got rolled back at session teardown:

```python
@account_blueprint.route("/logout")
@login_required
def logout():
    User.query.filter_by(id=current_user.id).delete()
    logout_user()
```

**Impact:** the `admin@admin.admin` row from the first login is still there on the second login attempt. The unconditional insert then violates the `email` unique constraint, `IntegrityError` propagates out of the view, and the admin gets a 500 instead of a session — the account is effectively locked out of the web UI after the very first login/logout cycle.

**Fix:** `login()` now looks the user up by email first and only inserts when the row is absent, so re-logins reuse the existing account instead of colliding with it. The no-op `delete()` in `logout()` is removed (it never persisted, so removing it changes nothing observable) and `logout_user()` alone ends the session; the now-unused `current_user` import was dropped with it.

No behaviour change beyond fixing the crash: logout still ends the session the same way it always effectively did.

### Verification

`website/` has no automated test coverage in this repository. Verification was:
- `python -m py_compile` on the changed file — clean (`website/` is excluded from flake8 in CI; `flake8` was also run manually on the file with no output).
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 247.81s (0:04:07).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

