### PR TITLE
[high] fix: [website] prune history with resolved session rows

### DIFF
--- a/website/app/session_class.py
+++ b/website/app/session_class.py
@@ -198,8 +198,8 @@ class Session_class:
 
         while len(histories) > get_limit_queries():
             history = History.query.order_by(History.id).all()
-            session = Session_db.query.filter_by(id=history[0].session_id)
-            if not History_Tree.query.filter_by(session_uuid=session.uuid):
+            session = Session_db.query.filter_by(id=history[0].session_id).first()
+            if session and not History_Tree.query.filter_by(session_uuid=session.uuid).count():
                 Session_db.query.filter_by(id=history[0].session_id).delete()
             History.query.filter_by(id=history[0].id).delete()
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** History trimming on the website 500s and leaves the orphaned session rows it was written to delete.

- **Problem** — In `Session_class.save_info()` (`website/app/session_class.py`), the history-trimming path calls `Session_db.query.filter_by(...)` without `.first()` and then reads `.uuid` off the `Query` object, and tests a `Query` for truthiness as an existence check.
- **Fix** — Resolve the query with `.first()`, null-check it, and use `.count()` for the orphan check.
- **Effect** — Scans that push the history table past `QUERIES_LIMIT` no longer raise `AttributeError` and return a 500, and the orphaned `Session_db` rows are actually deleted.
<!-- /bluf -->

In `Session_class.save_info()`'s history-trimming loop, once the number of history rows exceeds `QUERIES_LIMIT`, the code did this:

```python
session = Session_db.query.filter_by(id=history[0].session_id)
if not History_Tree.query.filter_by(session_uuid=session.uuid):
    Session_db.query.filter_by(id=history[0].session_id).delete()
```

`Session_db.query.filter_by(...)` returns a SQLAlchemy `Query` object, not a row — it was never resolved with `.first()`. Accessing `.uuid` on that `Query` raises `AttributeError`. Separately, `if not History_Tree.query.filter_by(...)` tests the truthiness of a `Query` object, which is always truthy, so that branch is always `False` and the guarded delete of orphaned `Session_db` rows never executes even once the `AttributeError` is fixed.

**Impact:** any scan that pushes the history table past `QUERIES_LIMIT` (100) crashes `save_info()` with an unhandled `AttributeError`, returning a 500 to the analyst instead of completing the scan. Independently, the orphaned `Session_db` row cleanup this code exists to perform never actually ran, so those rows accumulate indefinitely.

**Fix:** resolve the session query with `.first()` and null-check the result before using it, and replace the truthy-`Query` existence check with `.count()` so the orphan-delete guard actually evaluates the row count instead of `Query` truthiness.

This is a pure bug fix with no behaviour change to the intended history-pruning semantics.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification
- `python -m py_compile website/app/session_class.py`: clean (`website/` is excluded from flake8 in CI).
- The website has no automated test coverage in this repository (root `tests/` targets the live modules server only); verification here was `py_compile` plus confirming the module test suite still passes: 161 passed, 4 skipped, 5 subtests passed in 233.23s (0:03:53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

