### PR TITLE
[critical] fix: [website] require admin authentication for external tool management

### DIFF
--- a/website/app/external_tools/external_tools.py
+++ b/website/app/external_tools/external_tools.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, redirect, render_template, request
 from flask import session as sess
+from flask_login import current_user
 
 from app.utils import admin_user_active
 
@@ -27,11 +28,18 @@ def analyzers_data():
 @external_tools_blueprint.route("/add_external_tool", methods=["GET", "POST"])
 def add_external_tool():
     """Add a new tool"""
-    form = ExternalToolForm()
-    if form.validate_on_submit():
-        if ToolModel.add_tool_core(ToolModel.form_to_dict(form)):
-            return redirect("/external_tools")
-    return render_template("external_tools/add_external_tool.html", form=form)
+    sess["admin_user"] = admin_user_active()
+    flag = True
+    if sess.get("admin_user"):
+        if not current_user.is_authenticated:
+            flag = False
+    if flag:
+        form = ExternalToolForm()
+        if form.validate_on_submit():
+            if ToolModel.add_tool_core(ToolModel.form_to_dict(form)):
+                return redirect("/external_tools")
+        return render_template("external_tools/add_external_tool.html", form=form)
+    return render_template("404.html")
 
 
 @external_tools_blueprint.route(
@@ -39,11 +47,21 @@ def add_external_tool():
 )
 def delete_tool(tid):
     """Delete a tool"""
-    if ToolModel.get_tool(tid):
-        if ToolModel.delete_tool(tid):
-            return {"message": "Tool deleted", "toast_class": "success-subtle"}, 200
-        return {"message": "Error tool deleted", "toast_class": "danger-subtle"}, 400
-    return {"message": "Tool not found", "toast_class": "danger-subtle"}, 404
+    sess["admin_user"] = admin_user_active()
+    flag = True
+    if sess.get("admin_user"):
+        if not current_user.is_authenticated:
+            flag = False
+    if flag:
+        if ToolModel.get_tool(tid):
+            if ToolModel.delete_tool(tid):
+                return {"message": "Tool deleted", "toast_class": "success-subtle"}, 200
+            return {
+                "message": "Error tool deleted",
+                "toast_class": "danger-subtle",
+            }, 400
+        return {"message": "Tool not found", "toast_class": "danger-subtle"}, 404
+    return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
 
 
 @external_tools_blueprint.route(
@@ -51,15 +69,28 @@ def delete_tool(tid):
 )
 def change_status():
     """Active or disabled a tool"""
-    if "tool_id" in request.args:
-        res = ToolModel.change_status_core(request.args.get("tool_id"))
-        if res:
+    sess["admin_user"] = admin_user_active()
+    flag = True
+    if sess.get("admin_user"):
+        if not current_user.is_authenticated:
+            flag = False
+    if flag:
+        if "tool_id" in request.args:
+            res = ToolModel.change_status_core(request.args.get("tool_id"))
+            if res:
+                return {
+                    "message": "Tool status changed",
+                    "toast_class": "success-subtle",
+                }, 200
             return {
-                "message": "Tool status changed",
-                "toast_class": "success-subtle",
-            }, 200
-        return {"message": "Something went wrong", "toast_class": "danger-subtle"}, 400
-    return {"message": 'Need to pass "tool_id"', "toast_class": "warning-subtle"}, 400
+                "message": "Something went wrong",
+                "toast_class": "danger-subtle",
+            }, 400
+        return {
+            "message": 'Need to pass "tool_id"',
+            "toast_class": "warning-subtle",
+        }, 400
+    return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
 
 
 @external_tools_blueprint.route(
@@ -67,42 +98,52 @@ def change_status():
 )
 def change_config():
     """Change configuration for a tool"""
-    if (
-        "tool_id" in request.json["result_dict"]
-        and request.json["result_dict"]["tool_id"]
-    ):
+    sess["admin_user"] = admin_user_active()
+    flag = True
+    if sess.get("admin_user"):
+        if not current_user.is_authenticated:
+            flag = False
+    if flag:
         if (
-            "tool_name" in request.json["result_dict"]
-            and request.json["result_dict"]["tool_name"]
+            "tool_id" in request.json["result_dict"]
+            and request.json["result_dict"]["tool_id"]
         ):
             if (
-                "tool_url" in request.json["result_dict"]
-                and request.json["result_dict"]["tool_url"]
+                "tool_name" in request.json["result_dict"]
+                and request.json["result_dict"]["tool_name"]
             ):
                 if (
-                    "tool_api_key" in request.json["result_dict"]
-                    and request.json["result_dict"]["tool_api_key"]
+                    "tool_url" in request.json["result_dict"]
+                    and request.json["result_dict"]["tool_url"]
                 ):
-                    res = ToolModel.change_config_core(request.json["result_dict"])
-                    if res:
+                    if (
+                        "tool_api_key" in request.json["result_dict"]
+                        and request.json["result_dict"]["tool_api_key"]
+                    ):
+                        res = ToolModel.change_config_core(request.json["result_dict"])
+                        if res:
+                            return {
+                                "message": "Config changed",
+                                "toast_class": "success-subtle",
+                            }, 200
                         return {
-                            "message": "Config changed",
-                            "toast_class": "success-subtle",
-                        }, 200
+                            "message": "Something went wrong",
+                            "toast_class": "danger-subtle",
+                        }, 400
                     return {
-                        "message": "Something went wrong",
-                        "toast_class": "danger-subtle",
+                        "message": 'Need to pass "tool_api_key"',
+                        "toast_class": "warning-subtle",
                     }, 400
                 return {
-                    "message": 'Need to pass "tool_api_key"',
+                    "message": 'Need to pass "tool_url"',
                     "toast_class": "warning-subtle",
                 }, 400
             return {
-                "message": 'Need to pass "tool_url"',
+                "message": 'Need to pass "tool_name"',
                 "toast_class": "warning-subtle",
             }, 400
         return {
-            "message": 'Need to pass "tool_name"',
+            "message": 'Need to pass "tool_id"',
             "toast_class": "warning-subtle",
         }, 400
-    return {"message": 'Need to pass "tool_id"', "toast_class": "warning-subtle"}, 400
+    return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403

--- a/website/app/models/models.py
+++ b/website/app/models/models.py
@@ -111,7 +111,6 @@ class ExternalTools(db.Model):
             "id": self.id,
             "url": self.url,
             "name": self.name,
-            "api_key": self.api_key,
             "is_active": self.is_active,
         }
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** External tool management on the website is unauthenticated and leaks tool API keys to any visitor.

- **Problem** — The four mutating routes in `website/app/external_tools/external_tools.py`, which add, delete, enable and reconfigure tools, have no admin check unlike the equivalent routes in `home.py`, and `ExternalTools.to_json()` in `models.py` returns the stored `api_key` in cleartext to anyone hitting `/external_tools/list`.
- **Fix** — Gate all four on `admin_user_active()` plus `current_user.is_authenticated` and drop `api_key` from `to_json()`.
- **Effect** — Only authenticated admins can change external tool configuration, and tool API keys are no longer served to the browser.
<!-- /bluf -->

### The defect

None of the mutating routes in `website/app/external_tools/external_tools.py` were gated behind admin authentication, unlike the equivalent module-config routes in `app/home.py`:

```python
@external_tools_blueprint.route("/add_external_tool", methods=["GET", "POST"])
def add_external_tool():
    """Add a new tool"""
    form = ExternalToolForm()
    if form.validate_on_submit():
        if ToolModel.add_tool_core(ToolModel.form_to_dict(form)):
            return redirect("/external_tools")
    return render_template("external_tools/add_external_tool.html", form=form)
```

`delete_tool`, `change_status`, and `change_config` had the same shape: no `admin_user_active()` / `current_user.is_authenticated` check before performing the action, unlike `home.py`'s `modules_config_data`/`change_config` (lines 244-282), which already gate on exactly that pair of checks.

Separately, `ExternalTools.to_json()` in `website/app/models/models.py` included `api_key` in cleartext, so `/external_tools/list` handed every stored external-tool API key to anyone who could reach that endpoint.

### Impact

An unauthenticated visitor to a MISP instance's website (in the common configuration where `admin_user_active()` is enabled — MISP instances with self-registration or public reachability) could add, delete, or rewrite external tool configurations, including pointing `tool_url` at an attacker-controlled endpoint. Because `tool_api_key` is later sent as an `X-API-KEY` header (`home_core.py:135`), rewriting the URL causes the analyst's stored API key to be exfiltrated to that attacker-controlled endpoint on the next legitimate use. Independently, the `/list` endpoint leaked every configured tool's API key in cleartext to anyone who could view the external tools page.

### The fix

Applied the identical `sess["admin_user"] = admin_user_active()` / `current_user.is_authenticated` inline-flag idiom already used for the equivalent routes in `app/home.py` to all four routes in `external_tools.py` (404 for the HTML form route, `{"message": "Permission denied", ...}` / 403 for the three JSON routes). Also dropped `api_key` from `ExternalTools.to_json()` so it is no longer returned by `/external_tools/list`.

### Behaviour change

This changes the `/list` response shape: the config UI's edit form no longer prefills the stored API key, so an admin retypes it when editing a tool's config — the form already refuses an empty key, so no functionality is lost, only the cleartext leak of previously-stored keys.

### Verification

`website/` has no automated test coverage in this repository. Verification was:
- `py_compile` clean on both changed files (`website/` is excluded from the CI flake8 run; no line exceeds 88 chars)
- The module test suite (`tests/`) still passes: 161 passed, 4 skipped, 5 subtests passed in 197.78s (0:03:17)

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

