### PR TITLE
[high] fix: [joe_parser] key process references by integer target id

### DIFF
--- a/misp_modules/lib/joe_parser.py
+++ b/misp_modules/lib/joe_parser.py
@@ -245,7 +245,7 @@ class JoeParser:
                 self.references[self.analysisinfo_uuid].append(
                     dict(referenced_uuid=process_object.uuid, relationship_type="calls")
                 )
-                self.process_references[(general["targetid"], general["path"])] = process_object.uuid
+                self.process_references[(int(general["targetid"]), general["path"])] = process_object.uuid
 
     def parse_fileactivities(self, process_uuid, fileactivities):
         for feature, files in fileactivities.items():


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `joe_parser` keys process references by string but reads them as int, so no lookup ever matches.

- **Problem** — `misp_modules/lib/joe_parser.py` inserts `process_references` keys using the raw string `general["targetid"]` at line 248, while every reader looks up with `int(...)`.
- **Fix** — Cast `targetid` to `int` at insertion, a one-line change aligning it with the existing consumers.
- **Effect** — Joe Sandbox imports stop silently dropping the `drops` relationship between a process and the files it created and the `contacts` relationship to contacted IPs. They also stop aborting the whole import with an uncaught `KeyError` when a URL is bound to a real process.
<!-- /bluf -->

### The defect

```python
self.process_references[(general["targetid"], general["path"])] = process_object.uuid
```

At `misp_modules/lib/joe_parser.py:248` this dict is keyed with `general["targetid"]`, which comes straight from the Joe Sandbox XML report and is therefore a **string**. Every consumer, however, looks the entry up with the id cast to `int`:

- `lib/joe_parser.py:110` — `reference_key = (int(droppedfile["@targetid"]), droppedfile["@process"])`
- `lib/joe_parser.py:550` — `self.process_references[(target_id, current_path)]` where `target_id = int(url["@targetid"])`
- `lib/joe_parser.py:592` — `self.process_references[(int(target), currentpath)]`

`("1", path) != (1, path)`, so none of these lookups ever matched the entry inserted at line 248.

### Impact

Importing a Joe Sandbox report via this module:
- silently drops the `drops` relationship between a process and the files it created — dropped-file objects end up attached to the analysis root instead of the process that dropped them;
- silently drops the `contacts` relationship between a process and an IP it contacted, for the same reason;
- raises an uncaught `KeyError` and aborts the whole import when a URL is bound to a real process (`urlinfo`, line 550), since that path has no "attach to root" fallback.

An analyst pulling a Joe Sandbox report into MISP through this module either gets an event with broken/missing process relationships, or the import fails outright.

### The fix

Cast `targetid` to `int` at insertion time, matching what every reader already does:

```python
self.process_references[(int(general["targetid"]), general["path"])] = process_object.uuid
```

One-line change, no behaviour change beyond making the existing lookups actually succeed as intended.

### Verification

- `python -m py_compile misp_modules/lib/joe_parser.py` — clean (`misp_modules/lib/` is excluded from flake8 in CI).
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 179.00s (0:02:58). No dedicated unit test was added — the repository has no `joe_parser` test scaffolding, and the existing suite is live-server integration tests.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

