### PR TITLE
[high] fix: [mwdb] report successful sample uploads instead of a bogus failure

### DIFF
--- a/misp_modules/modules/expansion/mwdb.py
+++ b/misp_modules/modules/expansion/mwdb.py
@@ -4,7 +4,9 @@ import json
 import sys
 import zipfile
 
+import requests
 from mwdblib import MWDB
+from mwdblib.exc import MWDBError
 from pymisp import PyMISP
 
 # from distutils.util import strtobool
@@ -107,6 +109,7 @@ def handler(q=False):
     misp_attribute_comment = ""
     mwdb_tags = []
     misp_info = ""
+    misp_event = None
 
     try:
         if include_tags_event:
@@ -154,10 +157,10 @@ def handler(q=False):
         if len(misp_attribute_comment) < 1:
             misp_attribute_comment = "MISP attribute {}".format(misp_attribute_uuid)
         file_object.add_comment(misp_attribute_comment)
-        if len(misp_event) > 0:
+        if misp_event and len(misp_event) > 0:
             file_object.add_comment("Fetched from event {} - {}".format(misp_event_id, misp_info))
         mwdb_link = request["config"].get("mwdb_url").replace("/api", "/file/") + "{}".format(file_object.md5)
-    except Exception:
+    except (MWDBError, requests.exceptions.RequestException):
         misperrors["error"] = "Unable to send sample to MWDB instance"
         return misperrors
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `mwdb` reports successful sample uploads as failures, which had been driving duplicate uploads.

- **Problem** — In `misp_modules/modules/expansion/mwdb.py`, `misp_event` is bound only inside the `if include_tags_event:` branch, yet the upload block unconditionally evaluates `len(misp_event)`, raising `NameError` under the default configuration after the sample has already been uploaded; the broad `except Exception` then reports "Unable to send sample to MWDB instance".
- **Fix** — Initialise `misp_event = None`, guard the length check, and narrow that handler to `MWDBError` and `requests` exceptions.
- **Effect** — Analysts on default settings stop seeing successful uploads reported as failures.
<!-- /bluf -->

In `misp_modules/modules/expansion/mwdb.py`, `misp_event` was only ever bound inside the `if include_tags_event:` branch of the first `try` block:

```python
try:
    if include_tags_event:
        ...
        misp_event = misp.get_event(misp_event_id)
        ...
```

Yet the second `try` block, in the upload path, unconditionally reads it:

```python
        file_object.add_comment(misp_attribute_comment)
        if len(misp_event) > 0:
            file_object.add_comment("Fetched from event {} - {}".format(misp_event_id, misp_info))
        mwdb_link = request["config"].get("mwdb_url").replace("/api", "/file/") + "{}".format(file_object.md5)
    except Exception:
        misperrors["error"] = "Unable to send sample to MWDB instance"
        return misperrors
```

With the default configuration (`include_tags_event` unset/false), `misp_event` is never assigned, so `len(misp_event)` raises `NameError` — after the sample has already been uploaded to MWDB. The broad `except Exception` swallows that `NameError` and reports `"Unable to send sample to MWDB instance"`.

**Impact:** an analyst using this module with the default configuration sees every upload reported as a failure, even though the sample was successfully uploaded to MWDB. This is misleading and can cause duplicate uploads or lost trust in the module's output.

**Fix:** initialise `misp_event = None` alongside the other locals at the top of `handler()`, guard the length check with `if misp_event and len(misp_event) > 0:`, and narrow the upload block's `except Exception` to `except (MWDBError, requests.exceptions.RequestException):` so only genuine MWDB/network failures are reported as an upload failure — a stray `NameError` or other bug will now surface instead of being silently mislabelled.

The narrowed exception types were verified against `mwdblib`, which raises `MWDBError` subclasses for API-level failures, and re-raises `requests` `ConnectionError`/other `RequestException` subclasses unwrapped after its own retries.

This does not change any default behaviour for successful uploads or for genuine MWDB/network errors; it only stops a successful upload from being misreported as a failure, and stops unrelated bugs from being masked as MWDB upload failures.

### Verification
- `flake8 misp_modules/modules/expansion/mwdb.py` — clean.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 151.82s (0:02:31)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

