### PR TITLE
[medium] fix: [qintel] raise on exhausted API retries instead of returning None

### DIFF
--- a/misp_modules/lib/qintel_helper.py
+++ b/misp_modules/lib/qintel_helper.py
@@ -76,26 +76,24 @@ def _search(**kwargs):
         if response.code not in [429, 504]:
             raise Exception(f"API connection error: {response}")
 
-        if request_attempts < max_retries:
-            wait_time = _get_request_wait_time(request_attempts)
+        wait_time = _get_request_wait_time(request_attempts)
 
-            if response.code == 429:
-                msg = "rate limit reached on attempt {request_attempts}, waiting {wait_time} seconds"
+        if response.code == 429:
+            msg = "rate limit reached on attempt {request_attempts}, waiting {wait_time} seconds"
 
-                if logger:
-                    logger(msg)
-
-            else:
-                msg = f"connection timed out, retrying in {wait_time} seconds"
-                if logger:
-                    logger(msg)
-
-            sleep(wait_time)
+            if logger:
+                logger(msg)
 
         else:
-            raise Exception("Max API retries exceeded")
+            msg = f"connection timed out, retrying in {wait_time} seconds"
+            if logger:
+                logger(msg)
+
+        sleep(wait_time)
 
         request_attempts += 1
+
+    raise Exception("Max API retries exceeded")
 
 
 def _set_headers(**kwargs):


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Exhausted Qintel API retries return `None` instead of raising, leaving callers an opaque error.

- **Problem** — The retry loop in `_search` (`misp_modules/lib/qintel_helper.py`) guards its raise with an inner `if request_attempts < max_retries` that duplicates the `while` condition and is evaluated before the counter increments, so the `else` branch is dead and `_search` falls off the end returning `None`.
- **Fix** — Remove the redundant condition, dedent the wait/log/sleep block, and move `raise Exception("Max API retries exceeded")` after the loop.
- **Effect** — When the Qintel API rate-limits or times out repeatedly, the five callers get that informative exception instead of an opaque `AttributeError` on `NoneType.read()`.
<!-- /bluf -->

The retry loop in `qintel_helper.py`'s `_search` had a dead error branch:

```python
while request_attempts < max_retries:
    ...
    if request_attempts < max_retries:
        wait_time = _get_request_wait_time(request_attempts)
        ...
        sleep(wait_time)
    else:
        raise Exception("Max API retries exceeded")

    request_attempts += 1
```

The inner `if request_attempts < max_retries` duplicates the `while` loop's own guard and is evaluated *before* `request_attempts` is incremented, so it is always true inside the loop body — the `else` branch (and its `raise`) can never execute. When retries are actually exhausted, the `while` condition simply becomes false and `_search` falls off the end of the function, returning `None` instead of raising.

**Impact:** All five callers of `_search` (`search_pmi`, `search_qwatch`, `search_qauth`, `search_qsentry`, `qsentry_feed`) immediately call `.read()` on the result. When the Qintel API rate-limits or times out repeatedly, the analyst doesn't see the intended `Exception("Max API retries exceeded")` — they get an opaque `AttributeError: 'NoneType' object has no attribute 'read'` deep in the module, with no indication that the real cause was exhausted retries against the Qintel API.

**Fix:** Removed the redundant inner condition, dedented the wait/log/sleep block so it always runs inside the loop, and moved `raise Exception("Max API retries exceeded")` to after the `while` loop, so it fires exactly when the loop exits because retries are exhausted. This is the only behavior change: on retry exhaustion the caller now gets the intended, informative exception instead of an unrelated `AttributeError` several frames later.

### Verification

- `python -m py_compile misp_modules/lib/qintel_helper.py` — clean. (This file lives under `misp_modules/lib/`, which the repo's flake8 CI config excludes.)
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 176.98s (0:02:56), matching the expected baseline exactly.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

