### PR TITLE
[high] fix: [greynoise] propagate query errors instead of reporting empty success

### DIFF
--- a/misp_modules/modules/expansion/greynoise.py
+++ b/misp_modules/modules/expansion/greynoise.py
@@ -322,14 +322,18 @@ def handler(q=False):
         try:
             ipaddress.IPv4Address(attribute["value"])
             if "persistent" in request:
-                greynoise_parser.query_greynoise_ip_hover(request["config"]["api_key"])
+                error = greynoise_parser.query_greynoise_ip_hover(request["config"]["api_key"])
             else:
-                greynoise_parser.query_greynoise_ip_expansion(request["config"]["api_key"])
+                error = greynoise_parser.query_greynoise_ip_expansion(request["config"]["api_key"])
+            if error is not None:
+                return error
         except ValueError:
             return {"error": "Not a valid IPv4 address"}
 
     if attribute["type"] == "vulnerability":
-        greynoise_parser.query_greynoise_vulnerability(request["config"]["api_key"])
+        error = greynoise_parser.query_greynoise_vulnerability(request["config"]["api_key"])
+        if error is not None:
+            return error
 
     return greynoise_parser.get_result()
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `greynoise` swallows query errors and returns an empty result that looks like success.

- **Problem** — `handler()` in `misp_modules/modules/expansion/greynoise.py` invokes `query_greynoise_ip_hover`, `query_greynoise_ip_expansion` and `query_greynoise_vulnerability` as bare statements and then unconditionally returns `get_result()`, discarding the `misperrors` dict those methods return on failure.
- **Fix** — Capture each return value and return it immediately when it is not `None`.
- **Effect** — A bad API key, a GreyNoise outage or an unsupported Community-key vulnerability lookup surfaces as an error rather than a successful-looking empty enrichment implying GreyNoise found nothing.
<!-- /bluf -->

In `misp_modules/modules/expansion/greynoise.py`, `handler()` called the query functions as bare statements and discarded their return value:

```python
if "persistent" in request:
    greynoise_parser.query_greynoise_ip_hover(request["config"]["api_key"])
else:
    greynoise_parser.query_greynoise_ip_expansion(request["config"]["api_key"])
...
if attribute["type"] == "vulnerability":
    greynoise_parser.query_greynoise_vulnerability(request["config"]["api_key"])

return greynoise_parser.get_result()
```

Each of these query methods returns a `misperrors` dict when the query fails (bad API key, GreyNoise outage, unsupported vulnerability lookup on a Community key, etc.), but that return value was never captured, and `handler()` unconditionally returned `get_result()` afterward.

**Impact:** when GreyNoise enrichment fails for any reason, the analyst sees a successful-looking response with an empty enrichment instead of an error, silently masking outages or credential problems and giving a false sense that "GreyNoise checked this IP and found nothing."

**Fix:** capture each query call's return value and `return` it immediately when it is not `None`, matching the error-return pattern already used inside the parser methods. Success paths are unaffected, since those methods fall off the end (implicit `None`) when the query succeeds.

No behaviour change beyond correctly surfacing pre-existing error paths that were previously swallowed.

### Verification
- `flake8` on the changed file: clean, no output.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 144.87s (0:02:24), matching the pre-existing baseline.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

