### PR TITLE
[high] fix: [lastline_query] coerce verify_ssl to a string before parsing it

### DIFF
--- a/misp_modules/modules/expansion/lastline_query.py
+++ b/misp_modules/modules/expansion/lastline_query.py
@@ -93,7 +93,7 @@ def handler(q=False):
         api_client = lastline_api.PortalClient(
             api_url,
             auth_data,
-            verify_ssl=config.get("verify_ssl", True).lower() in ("true"),
+            verify_ssl=str(config.get("verify_ssl", True)).lower() in ("true", "1", "yes"),
         )
         response = api_client.get_progress(task_uuid)
         if response.get("completed") != 1:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `lastline_query` lookups abort with an `AttributeError` under the default `verify_ssl`.

- **Problem** — `misp_modules/modules/expansion/lastline_query.py` calls `config.get("verify_ssl", True).lower()`, which raises `AttributeError: 'bool' object has no attribute 'lower'` on the bool default, and its `in ("true")` test is a substring check on a string rather than tuple membership.
- **Fix** — Coerce the config value with `str()` before `.lower()` and compare against a real tuple of accepted truthy strings.
- **Effect** — Lastline task-status queries work on default configuration instead of failing before the API call, and SSL verification remains the default.
<!-- /bluf -->

### The defect

```python
verify_ssl=config.get("verify_ssl", True).lower() in ("true"),
```

`config.get("verify_ssl", True)` returns the Python bool `True` when `verify_ssl` isn't explicitly set in the module configuration. Calling `.lower()` on a bool raises `AttributeError: 'bool' object has no attribute 'lower'`, so the `handler()` call aborts before it ever reaches the Lastline API. Separately, `in ("true")` is not a tuple membership test — `("true")` is just the string `"true"` with redundant parens, so the expression actually checks substring containment against `.lower()`'s result.

### Impact

Every `lastline_query` lookup fails with `Error issuing the API call: 'bool' object has no attribute 'lower'` unless an analyst has gone out of their way to set `verify_ssl` explicitly (as a string) in the module's configuration. For any MISP instance running this module with defaults, Lastline task-status queries are completely broken.

### Fix

Coerce the config value to a string before calling `.lower()`, and compare against a real tuple of accepted truthy strings:

```python
verify_ssl=str(config.get("verify_ssl", True)).lower() in ("true", "1", "yes"),
```

### Behaviour note

This is a bug fix, not an intentional behaviour change: the previous code could never run to completion with the default config, so there is no working default behaviour being altered. The old `in ("true")` substring check also happened to treat oddities like `"rue"` as truthy — the new tuple check is a stricter, correct membership test, and it additionally accepts `"1"`/`"yes"` as truthy, which is more permissive but not less safe (SSL verification remains the default and only an explicit falsy-looking string disables it).

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/`: clean
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 168.94s (0:02:48)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

