### PR TITLE
[high] fix: [abuseipdb] propagate DNS resolution failures instead of crashing

### DIFF
--- a/misp_modules/modules/expansion/abuseipdb.py
+++ b/misp_modules/modules/expansion/abuseipdb.py
@@ -69,7 +69,10 @@ def handler(q=False):
         or request["attribute"]["type"] == "domain"
         or request["attribute"]["type"] == "domain|ip"
     ):
-        ip = get_ip(request)[0]
+        ip = get_ip(request)
+        if isinstance(ip, dict):
+            return ip
+        ip = ip[0]
 
     else:
         ip = request["attribute"]["value"]


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `abuseipdb` raises `KeyError: 0` instead of reporting a DNS resolution failure.

- **Problem** — the hostname/domain/domain|ip branch of `handler` in `misp_modules/modules/expansion/abuseipdb.py` does `ip = get_ip(request)[0]`, but `get_ip` returns the `misperrors` dict rather than a tuple when resolution fails, so indexing it with `[0]` raises `KeyError: 0`.
- **Fix** — checks `isinstance(ip, dict)` immediately after the call and returns it, using the error shape `get_ip` already produces.
- **Effect** — enriching a sinkholed, expired or taken-down domain, a routine IOC case, yields the informative error response instead of an unhandled exception; the success path is unchanged.
<!-- /bluf -->

The `handler` function's hostname/domain/domain|ip branch indexes the DNS resolution result unconditionally:

```python
ip = get_ip(request)[0]
```

`get_ip` returns the `misperrors` dict — not a tuple — whenever resolution fails (NXDOMAIN, resolver timeout, or any other lookup error). Indexing that dict with `[0]` raises `KeyError: 0`, so the module crashes instead of reporting the DNS error.

**Impact:** An analyst enriching a `hostname`, `domain`, or `domain|ip` attribute that no longer resolves (a sinkholed, expired, or since-taken-down domain — a common case in IOC enrichment) gets an unhandled exception from the module instead of the informative `{"error": ...}` response the module already knows how to produce.

**Fix:** Check `isinstance(ip, dict)` right after calling `get_ip` and return it immediately in that case, before attempting to index it. This uses the error-handling shape `get_ip` already returns; no behavior change for the success path.

No behaviour change: this only replaces a crash with the existing, already-implemented error-reporting path.

### Verification
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/` — clean, no output.
- Full test suite: 161 passed, 4 skipped, 5 subtests passed in 162.97s (0:02:42). No test exercises `abuseipdb` (it needs an API key), so none of the passing/skipped counts change; no failures.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

