### PR TITLE
[high] fix: [eql] initialise attrType before the supported-type loop

### DIFF
--- a/misp_modules/modules/expansion/eql.py
+++ b/misp_modules/modules/expansion/eql.py
@@ -55,6 +55,7 @@ def handler(q=False):
     config = request.get("config", {"Default_Source": ""})
     logging.info("Setting config to: %s", config)
 
+    attrType = None
     for supportedType in fieldmap.keys():
         if request.get(supportedType):
             attrType = supportedType


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `eql` module raises `UnboundLocalError` on any request with no supported attribute type.

- **Problem** — the `eql` expansion module's `handler` assigns `attrType` only inside the loop over `fieldmap` keys, so a request carrying no supported attribute type leaves the name unbound and `if attrType:` raises `UnboundLocalError` instead of reaching the `else` branch.
- **Fix** — initialises `attrType = None` before the loop.
- **Effect** — analysts enriching an unsupported attribute type see the intended "Unsupported attributes type" error rather than a module traceback; the supported-type success path is untouched.
<!-- /bluf -->

The eql expansion module's handler only assigns `attrType` inside the loop that checks for supported attribute keys:

```python
for supportedType in fieldmap.keys():
    if request.get(supportedType):
        attrType = supportedType

if attrType:
    ...
else:
    misperrors["error"] = "Unsupported attributes type"
    return misperrors
```

If the incoming request carries none of the keys in `fieldmap` (i.e. no supported attribute type is present), `attrType` is never bound, and `if attrType:` raises `UnboundLocalError` instead of falling through to the intended `else` branch. An analyst enriching an unsupported attribute type gets an unhandled exception/traceback from the module instead of the friendly "Unsupported attributes type" error MISP is designed to surface.

### Fix

Initialise `attrType = None` immediately before the loop, so that when no supported key matches, the existing `if attrType:` / `else` guard behaves as intended and returns the proper error.

No behaviour change beyond fixing this crash: the success path (a supported attribute type present) is untouched.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `flake8` clean on `misp_modules/modules/expansion/eql.py`.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 149.16s (0:02:29), run against a local modules server on port 6714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

