### PR TITLE
[high] fix: [xforceexchange] guard against a failed DNS resolve API call

### DIFF
--- a/misp_modules/modules/expansion/xforceexchange.py
+++ b/misp_modules/modules/expansion/xforceexchange.py
@@ -140,7 +140,7 @@ class XforceExchange:
 
     def _parse_dns(self, value):
         dns_result = self._api_call(f"{self.base_url}/resolve/{value}")
-        if dns_result.get("Passive") and dns_result["Passive"].get("records"):
+        if dns_result and dns_result.get("Passive") and dns_result["Passive"].get("records"):
             itype, ftype, value = self._fetch_types(dns_result["Passive"]["query"])
             misp_object = MISPObject("domain-ip")
             misp_object.add_attribute(itype, value)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** X-Force domain, IP and URL enrichment crashes whenever the DNS resolve call does not return 200.

- **Problem** — `_parse_dns` in `misp_modules/modules/expansion/xforceexchange.py` dereferences the response without a `None` check, but `_api_call` returns `None` on any non-200 — which X-Force routinely gives (404 for no passive DNS history, 401, 429) — producing `AttributeError` on `NoneType`.
- **Fix** — adds the same `if dns_result and ...` guard the sibling parsers already use.
- **Effect** — domain, IP and URL enrichment, which all route through `_parse_dns`, fall through to the existing error reporting (rate limit, not found) instead of crashing.
<!-- /bluf -->

`_parse_dns` in `xforceexchange.py` dereferences the X-Force API response without checking whether it's `None`:

```python
def _parse_dns(self, value):
    dns_result = self._api_call(f"{self.base_url}/resolve/{value}")
    if dns_result.get("Passive") and dns_result["Passive"].get("records"):
```

`_api_call` returns `None` whenever the request does not come back with a 200 status. X-Force routinely returns 404 for a domain or IP that has no passive DNS history, and can also return 401/429. In any of those cases `dns_result` is `None`, and `dns_result.get("Passive")` raises `AttributeError: 'NoneType' object has no attribute 'get'`.

**Impact:** an analyst enriching a domain or IP through this module hits an unhandled exception instead of the informative error already stored in `self.result` (e.g. rate-limit or not-found), so the module output is a crash instead of a usable (even if empty) enrichment result. Since `_parse_ip` and `_parse_url` both delegate to `_parse_dns`, the crash affects domain, IP, and URL enrichment alike.

**Fix:** add the same `if dns_result and ...` guard that the sibling parsers (`_parse_hash`, `_parse_malware`, `_parse_vulnerability`) already use, so a failed/empty API response falls through to the existing error handling instead of crashing.

No behaviour change beyond repairing the crash — the guard makes `_parse_dns` consistent with the other parsers in the same file.

### Verification

- `flake8` on `misp_modules/modules/expansion/xforceexchange.py`: clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 127.87s (0:02:07)`, run against a live local test server; results matched the expected baseline.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

