### PR TITLE
[high] fix: [sigmf_expand] initialise recording attributes before None checks

### DIFF
--- a/misp_modules/modules/expansion/sigmf_expand.py
+++ b/misp_modules/modules/expansion/sigmf_expand.py
@@ -194,6 +194,8 @@ def process_sigmf_archive(object):
 def process_sigmf_recording(object):
 
     event = MISPEvent()
+    sigmf_data_attr = None
+    sigmf_meta_attr = None
 
     for attribute in object["Attribute"]:
         if attribute["object_relation"] == "SigMF-data":
@@ -203,10 +205,10 @@ def process_sigmf_recording(object):
             sigmf_meta_attr = attribute
 
     if sigmf_meta_attr is None:
-        return {"error": "No SigMF-data attribute"}
+        return {"error": "No SigMF-meta attribute"}
 
     if sigmf_data_attr is None:
-        return {"error": "No SigMF-meta attribute"}
+        return {"error": "No SigMF-data attribute"}
 
     try:
         sigmf_meta = base64.b64decode(sigmf_meta_attr["data"]).decode("utf-8")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A `sigmf-recording` object missing a relation returns an unhandled 500 instead of a clear error.

- **Problem** — `process_sigmf_recording` in `sigmf_expand.py` binds `sigmf_data_attr` and `sigmf_meta_attr` only inside its attribute loop, so a missing relation makes the following `is None` guard itself raise an uncaught `UnboundLocalError`; the two error strings were also swapped.
- **Fix** — pre-initialises both variables to `None`, matching `process_sigmf_archive`, and corrects each message to name the relation it actually checks.
- **Effect** — enriching a partially-populated object returns the intended "No SigMF-meta/data attribute" error naming the right relation, instead of an unhandled 500.
<!-- /bluf -->

### The defect

In `process_sigmf_recording`, `sigmf_data_attr` and `sigmf_meta_attr` were only bound inside the attribute loop:

```python
for attribute in object["Attribute"]:
    if attribute["object_relation"] == "SigMF-data":
        sigmf_data_attr = attribute

    if attribute["object_relation"] == "SigMF-meta":
        sigmf_meta_attr = attribute

if sigmf_meta_attr is None:
    return {"error": "No SigMF-data attribute"}

if sigmf_data_attr is None:
    return {"error": "No SigMF-meta attribute"}
```

If a `sigmf-recording` MISP object is missing the `SigMF-data` or `SigMF-meta` relation entirely, the corresponding local variable is never assigned inside the loop, so the `is None` guard itself raises `UnboundLocalError` when it references the name. This happens outside any `try/except`, so it isn't caught anywhere in the module. The two error strings were also swapped: the check on `sigmf_meta_attr` reported "No SigMF-data attribute" and vice versa.

### Impact

An analyst enriching a malformed or partially-populated `sigmf-recording` object (missing either relation) gets an unhandled 500 from the module instead of the clean, actionable "No SigMF-meta/data attribute" error MISP is supposed to surface — and if they get past that, the mislabeled error names the wrong missing relation, sending them to fix the wrong thing.

### The fix

Pre-initialise both `sigmf_data_attr` and `sigmf_meta_attr` to `None` at the top of the function (matching the existing pattern already used in `process_sigmf_archive`), and swap the two error strings so each guard names the relation it actually checks.

No behaviour change beyond turning the crash into the intended error message and correcting which relation each message names.

### Verification

- `flake8 misp_modules/modules/expansion/sigmf_expand.py` — clean.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 117.30s (0:01:57).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

