### PR TITLE
[high] fix: [sigmf_expand] process the archive inside the SigMF-archive branch

### DIFF
--- a/misp_modules/modules/expansion/sigmf_expand.py
+++ b/misp_modules/modules/expansion/sigmf_expand.py
@@ -145,43 +145,43 @@ def process_sigmf_archive(object):
 
                 sigmf_tarfile = tarfile.open(sigmf_archive_file.name, mode="r", format=tarfile.PAX_FORMAT)
 
-            files = sigmf_tarfile.getmembers()
+                files = sigmf_tarfile.getmembers()
 
-            for file in files:
-                if file.name.endswith(SIGMF_METADATA_EXT):
-                    metadata_reader = sigmf_tarfile.extractfile(file)
-                    sigmf_meta_attr = {
-                        "type": "attachment",
-                        "value": file.name,
-                        "data": base64.b64encode(metadata_reader.read()).decode("utf-8"),
-                        "comment": "SigMF metadata file",
-                        "object_relation": "SigMF-meta",
-                    }
+                for file in files:
+                    if file.name.endswith(SIGMF_METADATA_EXT):
+                        metadata_reader = sigmf_tarfile.extractfile(file)
+                        sigmf_meta_attr = {
+                            "type": "attachment",
+                            "value": file.name,
+                            "data": base64.b64encode(metadata_reader.read()).decode("utf-8"),
+                            "comment": "SigMF metadata file",
+                            "object_relation": "SigMF-meta",
+                        }
 
-                if file.name.endswith(SIGMF_DATASET_EXT):
-                    data_reader = sigmf_tarfile.extractfile(file)
-                    sigmf_data_attr = {
-                        "type": "attachment",
-                        "value": file.name,
-                        "data": base64.b64encode(data_reader.read()).decode("utf-8"),
-                        "comment": "SigMF data file",
-                        "object_relation": "SigMF-data",
-                    }
+                    if file.name.endswith(SIGMF_DATASET_EXT):
+                        data_reader = sigmf_tarfile.extractfile(file)
+                        sigmf_data_attr = {
+                            "type": "attachment",
+                            "value": file.name,
+                            "data": base64.b64encode(data_reader.read()).decode("utf-8"),
+                            "comment": "SigMF data file",
+                            "object_relation": "SigMF-data",
+                        }
 
-            if sigmf_meta_attr is None:
-                return {"error": "No SigMF metadata file found"}
+                if sigmf_meta_attr is None:
+                    return {"error": "No SigMF metadata file found"}
 
-            recording = MISPObject("sigmf-recording")
-            recording.add_attribute(**sigmf_meta_attr)
-            recording.add_attribute(**sigmf_data_attr)
+                recording = MISPObject("sigmf-recording")
+                recording.add_attribute(**sigmf_meta_attr)
+                recording.add_attribute(**sigmf_data_attr)
 
-            # add reference to original SigMF Archive object
-            recording.add_reference(object["uuid"], "expands")
+                # add reference to original SigMF Archive object
+                recording.add_reference(object["uuid"], "expands")
 
-            event.add_object(recording)
-            event = json.loads(event.to_json())
+                event.add_object(recording)
+                event = json.loads(event.to_json())
 
-            return {"results": {"Object": event["Object"]}}
+                return {"results": {"Object": event["Object"]}}
 
         # no sigmf-archive attribute found
         return {"error": "No SigMF-archive attribute found"}


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** SigMF archive enrichment fails or succeeds depending on the order of attributes in the object.

- **Problem** — in `process_sigmf_archive` in `misp_modules/modules/expansion/sigmf_expand.py`, the archive-processing block is indented one level too shallow, so it runs for every attribute rather than only the SigMF-archive one, raising `UnboundLocalError` on `sigmf_tarfile` whenever another attribute comes first.
- **Fix** — re-indents that block into the SigMF-archive branch; the change is whitespace-only, with no logic change.
- **Effect** — analysts enriching a `sigmf-archive` object get the expected `sigmf-recording` object instead of a generic "An error occured when processing the SigMF archive" message that depended on attribute ordering.
<!-- /bluf -->

The archive-processing logic in `process_sigmf_archive` was indented at the wrong level:

```python
        for attribute in object["Attribute"]:
            if attribute["object_relation"] == "SigMF-archive":

                sigmf_tarfile = tarfile.open(sigmf_archive_file.name, mode="r", format=tarfile.PAX_FORMAT)

            files = sigmf_tarfile.getmembers()   # <-- at `for` level, not `if` level

            for file in files:
                ...
            if sigmf_meta_attr is None:
                return {"error": "No SigMF metadata file found"}
            ...
            return {"results": {"Object": event["Object"]}}
```

Because the block from `files = sigmf_tarfile.getmembers()` through the final `return` was indented one level too shallow, it ran for *every* attribute in the object's `Attribute` list, not only for the `SigMF-archive` one. Whenever an attribute other than `SigMF-archive` was iterated first, `sigmf_tarfile` was not yet defined and the code raised `UnboundLocalError`, which the surrounding broad `except Exception` swallowed into the generic `"An error occured when processing the SigMF archive"` message.

**Impact:** any MISP analyst enriching a `sigmf-archive` object whose `Attribute` list has a non-archive attribute before the `SigMF-archive` attribute gets a useless generic error instead of the expected `sigmf-recording` object — the module effectively fails on ordering it shouldn't care about.

**Fix:** re-indent the archive-processing block (getting the tar members, building the meta/data attributes, constructing and returning the `sigmf-recording` object) so it lives inside the `if attribute["object_relation"] == "SigMF-archive":` branch, alongside the code that opens the tarfile. This is a whitespace-only change; no logic was altered.

### Verification
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/expansion/sigmf_expand.py` — clean, no output.
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 121.78s (0:02:01)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

