### PR TITLE
[high] fix: [yeti] handle a Yeti search that finds no observable

### DIFF
--- a/misp_modules/modules/expansion/yeti.py
+++ b/misp_modules/modules/expansion/yeti.py
@@ -83,6 +83,8 @@ class Yeti:
 
     def parse_yeti_result(self):
         obs = self.search(self.attribute["value"])
+        if not obs:
+            return
 
         for obs_to_add, link in self.get_neighboors(obs["id"]):
             object_misp_domain_ip = self.__get_object_domain_ip(obs_to_add)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `yeti` module crashes with a `TypeError` whenever Yeti has no matching observable.

- **Problem** — in `expansion/yeti.py`, `search()` implicitly returns `None` when `observable_search` finds nothing, and `parse_yeti_result()` immediately does `obs["id"]`, raising `TypeError: 'NoneType' object is not subscriptable`.
- **Fix** — `parse_yeti_result()` now checks `obs` for falsiness right after the search call and returns early; `search()` itself is unchanged.
- **Effect** — the common case of a lookup with no prior Yeti hit falls back to the module's normal empty-result behaviour instead of crashing, so the module is usable on that path.
<!-- /bluf -->

The Yeti expansion module dereferences a `None` search result:

```python
def search(self, value):
    obs = self.yeti_client.observable_search(value=value)
    if obs:
        return obs[0]
    # implicit `return None` when nothing is found

def parse_yeti_result(self):
    obs = self.search(self.attribute["value"])

    for obs_to_add, link in self.get_neighboors(obs["id"]):
```

When `observable_search` finds no matching observable in Yeti, `search()` implicitly returns `None`, and `parse_yeti_result()` immediately does `obs["id"]` on it.

**Impact:** any MISP analyst who runs the Yeti enrichment module against an attribute value that Yeti does not know about gets an unhandled `TypeError: 'NoneType' object is not subscriptable` instead of a clean "no results" response. This is the common case for the module (most lookups won't have a prior Yeti hit), so the module is effectively broken for that path.

**Fix:** `parse_yeti_result()` now checks `obs` for falsiness right after the search call and returns early when there is no hit, leaving the module to fall back to its normal "echo the input attribute, add no context" empty-result behaviour. `search()` itself is unchanged.

No behaviour change beyond turning a crash into the correct empty-result response for a lookup with no Yeti hit.

### Verification
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/expansion/yeti.py` — clean, no output.
- Full test suite: 161 passed, 4 skipped, 5 subtests passed in 121.19s (0:02:01).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

