### PR TITLE
[high] fix: [mcafee_insights_enrich] stop killing the server on API errors

### DIFF
--- a/misp_modules/modules/expansion/mcafee_insights_enrich.py
+++ b/misp_modules/modules/expansion/mcafee_insights_enrich.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-import sys
 
 import requests
 from pymisp import MISPAttribute, MISPEvent, MISPObject
@@ -28,6 +27,10 @@ moduleinfo = {
 
 # config fields that your code expects from the site admin
 moduleconfig = ["api_key", "client_id", "client_secret"]
+
+
+class MVAPIError(Exception):
+    pass
 
 
 class MVAPI:
@@ -73,7 +76,9 @@ class MVAPI:
             self.logger.error(
                 "Could not authenticate to get the IAM token: {0} - {1}".format(res.status_code, res.text)
             )
-            sys.exit()
+            raise MVAPIError(
+                "Could not authenticate to get the IAM token: {0} - {1}".format(res.status_code, res.text)
+            )
         else:
             self.logger.info("Successful authenticated.")
             access_token = res.json()["access_token"]
@@ -94,15 +99,20 @@ class MVAPI:
         if res.ok:
             if len(res.json()["data"]) == 0:
                 self.logger.info("No Hash details in MVISION Insights found.")
+                return None
             else:
                 self.logger.info("Successfully retrieved MVISION Insights details.")
                 self.logger.debug(res.text)
                 return res.json()
         else:
             self.logger.error("Error in search_ioc. HTTP {0} - {1}".format(str(res.status_code), res.text))
-            sys.exit()
+            raise MVAPIError("Error in search_ioc. HTTP {0} - {1}".format(str(res.status_code), res.text))
 
     def prep_result(self, ioc):
+        if ioc is None:
+            misperrors["error"] = "No Hash details in MVISION Insights found."
+            return misperrors
+
         res = ioc["data"][0]
         results = []
 
@@ -243,8 +253,12 @@ def handler(q=False):
     client_secret = request["config"]["client_secret"]
     attribute = request["attribute"]
 
-    mvi = MVAPI(attribute, api_key, client_id, client_secret)
-    res = mvi.search_ioc()
+    try:
+        mvi = MVAPI(attribute, api_key, client_id, client_secret)
+        res = mvi.search_ioc()
+    except MVAPIError as e:
+        misperrors["error"] = str(e)
+        return misperrors
     return mvi.prep_result(res)
 
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An API error in `mcafee_insights_enrich` no longer tears down the whole misp-modules server.

- **Problem** — `expansion/mcafee_insights_enrich.py` calls `sys.exit()` on an IAM auth failure and on a non-200 from `search_ioc`, but modules run inside a long-running Twisted server, so the `SystemExit` kills the whole process and every other in-flight enrichment; separately an empty `data` list fell through and returned `None` into `prep_result()`, raising `TypeError`.
- **Fix** — both paths now raise a dedicated `MVAPIError` that `handler()` converts into a normal `misperrors` response, the empty branch returns `None` explicitly, and `prep_result()` reports that as an error.
- **Effect** — a transient McAfee API error or an empty hit gives a clean error response instead of killing the server for every module on it.
<!-- /bluf -->

### The defect

```python
if res.status_code != 200:
    self.logger.error(
        "Could not authenticate to get the IAM token: {0} - {1}".format(res.status_code, res.text)
    )
    sys.exit()
...
else:
    self.logger.error("Error in search_ioc. HTTP {0} - {1}".format(str(res.status_code), res.text))
    sys.exit()
```

`misp_modules` runs the expansion modules inside a long-running Twisted server process. Calling `sys.exit()` from inside a request handler raises `SystemExit`, which propagates up and kills the whole modules server, not just the one request — every other in-flight enrichment lookup on the server goes down with it. A single McAfee Insights auth failure or a non-200 response from `search_ioc` was enough to take out the entire server process.

Separately, when `search_ioc()` got a 200 response with an empty `data` list it logged a message but fell through with no `return`, so it returned `None` implicitly. That `None` was then passed straight into `prep_result(ioc)`, which does `ioc["data"][0]` and raises an unhandled `TypeError`.

### Impact

An analyst enriching an attribute with the MVISION Insights module hits a transient auth error, an HTTP error from the McAfee API, or simply a hash with no results, and the misp-modules server crashes or throws an unhandled exception instead of returning a normal "no results" / error response to MISP. Every other module running on that server instance is disrupted until it's restarted.

### The fix

Both `sys.exit()` calls now raise a dedicated `MVAPIError`, which `handler()` catches and converts into a normal `misperrors` response instead of tearing down the process. The empty-result branch of `search_ioc()` now returns `None` explicitly, and `prep_result()` checks for `None` and reports it as a `misperrors` message instead of crashing with a `TypeError`. No behaviour change for the success path — only the error paths now degrade gracefully instead of taking the server down.

### Verification

- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/` on the changed file: clean, no output.
- Full test suite: 161 passed, 4 skipped, 5 subtests passed in 95.18s (0:01:35), run against a local misp-modules server.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

