### PR TITLE
[high] fix: [sophoslabs_intelix] tolerate an unset region in the module config

### DIFF
--- a/misp_modules/modules/expansion/sophoslabs_intelix.py
+++ b/misp_modules/modules/expansion/sophoslabs_intelix.py
@@ -173,7 +173,7 @@ def handler(q=False):
             " https://aws.amazon.com/marketplace/pp/B07SLZPMCS."
         )
         return misperrors
-    if j["config"]["region"] not in ["us", "de", "au"]:
+    if j["config"].get("region") not in ["us", "de", "au"]:
         j["config"]["region"] = "de"
     to_check = (("type", "value"), ("type", "value1"))
     if not j.get("attribute") or not any(


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `sophoslabs_intelix` raises `KeyError` when the optional `region` config key is not set.

- **Problem** — `expansion/sophoslabs_intelix.py` direct-indexes `j["config"]["region"]` before its own `"de"` fallback on the next line can run, and the handler validates only `client_id` and `client_secret`, so an instance that enables the module without a region hits an unhandled `KeyError`.
- **Fix** — the direct index becomes `j["config"].get("region")`, so a missing key returns `None`, fails the membership test and falls into the existing default.
- **Effect** — enabling the module without a region now yields an enrichment result via the intended `"de"` default; configs that already set a region are unaffected.
<!-- /bluf -->

The optional `region` config key was direct-indexed before the fallback could apply:

```python
if j["config"]["region"] not in ["us", "de", "au"]:
    j["config"]["region"] = "de"
```

The handler validates only `client_id` and `client_secret`, so if a MISP instance's module config omits `region` (leaving it unset, as it is optional), `j["config"]["region"]` raises `KeyError` before the existing `"de"` fallback on the next line ever gets a chance to run.

**Impact:** an analyst who enables the `sophoslabs_intelix` expansion module but doesn't set a `region` gets an unhandled `KeyError` instead of the enrichment result — the module fails outright rather than defaulting to `"de"` as intended.

**Fix:** changed the direct index to `j["config"].get("region")`, so a missing key returns `None`, fails the `in [...]` membership check, and falls into the existing default assignment — no behaviour change for any config that already sets a valid or invalid region string.

### Verification

- `flake8` clean on `misp_modules/modules/expansion/sophoslabs_intelix.py`.
- Full test suite against a live modules server: `161 passed, 4 skipped, 5 subtests passed in 97.16s (0:01:37)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

