### PR TITLE
[high] fix: [vmray_submit] default unset optional flags to false

### DIFF
--- a/misp_modules/modules/expansion/vmray_submit.py
+++ b/misp_modules/modules/expansion/vmray_submit.py
@@ -92,9 +92,9 @@ def handler(q=False):
 
     api = VMRayRESTAPI(request["config"].get("url"), request["config"].get("apikey"), False)
 
-    shareable = request["config"].get("shareable")
-    do_not_reanalyze = request["config"].get("do_not_reanalyze")
-    do_not_include_vmrayjobids = request["config"].get("do_not_include_vmrayjobids")
+    shareable = request["config"].get("shareable") or "false"
+    do_not_reanalyze = request["config"].get("do_not_reanalyze") or "false"
+    do_not_include_vmrayjobids = request["config"].get("do_not_include_vmrayjobids") or "false"
 
     try:
         shareable = bool(strtobool(shareable))  # Do we want the sample to be shared?


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `vmray_submit` crashes on every submission when an optional flag is left unset in its config.

- **Problem** — `expansion/vmray_submit.py` reads the optional `shareable`, `do_not_reanalyze` and `do_not_include_vmrayjobids` keys with a bare `.get()` and passes the result to `strtobool`, which raises `AttributeError` on `None`; only `ValueError` is caught, so the exception escapes `handler()`.
- **Fix** — each of the three reads now falls back to `"false"` with `or "false"`.
- **Effect** — an instance that configured `vmray_submit` but left one of those flags unset now takes the documented default (not shared, reanalyze, include job IDs) instead of crashing; configs that already set the keys are unchanged.
<!-- /bluf -->

The optional VMRay settings are read straight from config and handed to `strtobool` with no default:

```python
shareable = request["config"].get("shareable")
do_not_reanalyze = request["config"].get("do_not_reanalyze")
do_not_include_vmrayjobids = request["config"].get("do_not_include_vmrayjobids")

try:
    shareable = bool(strtobool(shareable))
    reanalyze = not bool(strtobool(do_not_reanalyze))
    include_vmrayjobids = not bool(strtobool(do_not_include_vmrayjobids))
except ValueError:
    misperrors["error"] = "Error while processing settings. Please double-check your values."
    return misperrors
```

If any of these three optional config keys is left unset, `.get()` returns `None`, and `strtobool(None)` raises `AttributeError` (it calls `.lower()` on its argument internally). Only `ValueError` is caught, so the `AttributeError` propagates out of `handler()` uncaught.

**Impact:** any MISP instance that has configured `vmray_submit` but left one or more of `shareable`, `do_not_reanalyze`, or `do_not_include_vmrayjobids` unset will have the module crash on every submission attempt instead of falling back to its documented default behaviour (not shared, reanalyze, include job IDs) — a working-looking module that is actually unusable until an analyst notices and sets every optional flag explicitly.

**Fix:** each of the three reads now falls back to the string `"false"` with `or "false"`, which covers both a missing key and an explicit `None`/empty value, so an unset flag takes its documented default instead of crashing `strtobool`.

No behaviour change for instances that already set these keys; instances that left them unset now get the documented default instead of a crash.

### Verification

- `flake8` on `misp_modules/modules/expansion/vmray_submit.py`: clean, no output.
- Full test suite against a live server on port 6721: 161 passed, 4 skipped, 5 subtests passed in 113.51s (0:01:53) — matches the expected baseline.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

