### PR TITLE
[medium] fix: [anyrun_sandbox] require both API key and OS type

### DIFF
--- a/misp_modules/lib/anyrun_sandbox/submitter.py
+++ b/misp_modules/lib/anyrun_sandbox/submitter.py
@@ -50,7 +50,7 @@ class AnyRunSubmitter:
         self._token = self._config.pop("api_key", "")
         self._os_type = self._config.pop("os_type", "")
 
-        if not any((self._token, self._os_type)):
+        if not all((self._token, self._os_type)):
             raise RunTimeException(f"ANYRUN Sandbox API-KEY and OS type must be specified.")
 
         if "url" in self._request:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A partially configured ANY.RUN sandbox submitter now fails its own validation instead of submitting.

- **Problem** — The submitter in `lib/anyrun_sandbox/submitter.py` validates credentials with `if not any((self._token, self._os_type))`, which only raises when both `api_key` and `os_type` are missing, so a half-configured module passes the check with an empty token.
- **Fix** — Changes `any` to `all` so the guard fires whenever either required field is absent, matching the error message already written there.
- **Effect** — A partially configured instance gets the clear "API-KEY and OS type must be specified" message instead of an opaque authentication failure deep inside the ANY.RUN submission call.
<!-- /bluf -->

### Defect

```python
self._token = self._config.pop("api_key", "")
self._os_type = self._config.pop("os_type", "")

if not any((self._token, self._os_type)):
    raise RunTimeException(f"ANYRUN Sandbox API-KEY and OS type must be specified.")
```

`any()` only raises when **both** `api_key` and `os_type` are missing. If a MISP instance configures `os_type` but leaves `api_key` empty (or vice versa), the guard is satisfied and execution continues with `self._token == ""`.

### Impact

An analyst who partially configures the ANY.RUN sandbox module (e.g. sets `os_type` but forgets `api_key`) gets no validation error at submission time. Instead, an empty API key is passed straight into `SandboxConnector`, turning a configuration mistake into an opaque authentication failure against the ANY.RUN API deep inside the submission call, instead of the clear "API-KEY and OS type must be specified" message the code is already written to produce.

### Fix

Changed `any` to `all`, so the guard now raises whenever *either* required field is missing, matching the error message that was already in place.

### Verification

- `py_compile` on the changed file: clean.
- Full module test suite against a live `misp-modules` server (port 6723): 161 passed, 4 skipped, 5 subtests passed in 83.03s — matches the expected baseline.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

