### PR TITLE
[high] fix: [vmray] yield domain artifacts that have no resolved IP addresses

### DIFF
--- a/misp_modules/lib/_vmray/parser.py
+++ b/misp_modules/lib/_vmray/parser.py
@@ -841,9 +841,6 @@ class SummaryV2(ReportParser):
             )
 
             ref_ip_addresses = domain.get("ref_ip_addresses", [])
-            if not ref_ip_addresses:
-                continue
-
             for ip_address in self._resolve_refs(ref_ip_addresses):
                 ip = ip_address.get("ip_address")
                 if ip is not None:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** VMRay domain IOCs with no resolved IP addresses now reach MISP instead of being dropped.

- **Problem** — In `SummaryV2.artifacts()` in `misp_modules/lib/_vmray/parser.py`, a `continue` sat between constructing a `DomainArtifact` and yielding it, so any domain VMRay reported with no resolved IP addresses was discarded rather than emitted.
- **Fix** — Removes the two-line guard; the inner loop over `_resolve_refs()` is already a no-op on empty input, so such domains are yielded with an empty `ips` list, matching `SummaryV1` behaviour.
- **Effect** — Since v2 is the default summary format, analysts pivoting from a VMRay report now receive sinkholed, parked and other non-resolving domain IOCs that previously never reached MISP.
<!-- /bluf -->

### The defect

In `SummaryV2.artifacts()` (`misp_modules/lib/_vmray/parser.py`), the domain-artifact loop built each `DomainArtifact`, then dropped it before it could be yielded whenever it had no referenced IP addresses:

```python
ref_ip_addresses = domain.get("ref_ip_addresses", [])
if not ref_ip_addresses:
    continue

for ip_address in self._resolve_refs(ref_ip_addresses):
```

The `continue` sat between the `DomainArtifact(...)` construction and the eventual `yield artifact`, so any domain that VMRay reported with no resolved IP addresses was silently discarded instead of being emitted (with an empty `ips` list). `SummaryV1.artifacts()` yields its domain artifacts unconditionally, and v2 is the default summary format parsed for VMRay submissions.

### Impact

A sinkholed, parked, or otherwise non-resolving domain that VMRay still flags as an IOC (`is_ioc=True`) never reached MISP output at all when processed through the default v2 summary parser — an analyst pivoting from a VMRay sandbox report would lose exactly the domain IOCs least likely to have a live IP, i.e. often the most interesting ones.

### The fix

Removed the two-line guard so the domain artifact is always yielded; the inner loop over `self._resolve_refs(ref_ip_addresses)` is a no-op when `ref_ip_addresses` is empty (that helper returns early on falsy input), so domains with no IPs are now emitted with an empty `ips` list instead of being dropped, matching v1's behaviour.

This does not change any existing behaviour for domains that do have resolved IPs — it only stops discarding domains that have none.

### Verification

- `python -m py_compile misp_modules/lib/_vmray/parser.py` — clean. (`misp_modules/lib/` is excluded from the repo's flake8 config, so this is the applicable check.)
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 121.22s (0:02:01)` — matches the expected baseline exactly, no failures.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

