### PR TITLE
fix: [eupi] reject incomplete module config instead of crashing

### DIFF
--- a/misp_modules/modules/expansion/eupi.py
+++ b/misp_modules/modules/expansion/eupi.py
@@ -44,7 +44,7 @@ def handler(q=False):
         misperrors["error"] = "Unsupported attributes type"
         return misperrors
 
-    if not request.get("config") and not (request["config"].get("apikey") and request["config"].get("url")):
+    if not request.get("config") or not (request["config"].get("apikey") and request["config"].get("url")):
         misperrors["error"] = "EUPI authentication is missing"
         return misperrors
 


### PR DESCRIPTION
### The defect

```python
if not request.get("config") and not (request["config"].get("apikey") and request["config"].get("url")):
    misperrors["error"] = "EUPI authentication is missing"
    return misperrors
```

The two halves of this guard were joined with `and`, but they check mutually exclusive situations (config absent vs. config present-but-incomplete), so they can never both be true at once:

- If `request["config"]` is absent entirely, `not request.get("config")` is `True`, but Python still evaluates the right-hand side to resolve the `and`, and `request["config"]` raises `KeyError` because the key doesn't exist.
- If `config` is present but missing `apikey` and/or `url`, `not request.get("config")` is `False`, so the whole `and` short-circuits to `False` and the guard is skipped — execution falls through to `PyEUPI(request["config"]["apikey"], ...)` a few lines down, which raises `KeyError` there instead.

Either way the intended "friendly error" branch is unreachable, and the module raises an uncaught `KeyError` instead.

### Impact

Any MISP user who enables the `eupi` expansion module without a complete config (missing `config` block, or an `apikey`/`url` left blank) gets an unhandled exception/HTTP 500 out of the module instead of the clear message `"EUPI authentication is missing"`. This makes misconfiguration confusing to diagnose from the MISP UI.

### The fix

Changed the operator from `and` to `or`, so the guard fires — and returns the intended error — whenever `config` is missing at all, or present but incomplete (missing `apikey` or `url`). The inner `apikey and url` check is left intact since both values are dereferenced unconditionally on the next line.

No behaviour change beyond making the existing, already-written error message reachable; no new default or contract change.

### Verification

- `flake8` on `misp_modules/modules/expansion/eupi.py`: clean.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 115.25s (0:01:55)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
