### PR TITLE
[high] fix: [iprep] reject a config that carries no apikey

### DIFF
--- a/misp_modules/modules/expansion/iprep.py
+++ b/misp_modules/modules/expansion/iprep.py
@@ -38,7 +38,7 @@ def handler(q=False):
         misperrors["error"] = "Unsupported attributes type"
         return misperrors
 
-    if not request.get("config") and not request["config"].get("apikey"):
+    if not request.get("config") or not request["config"].get("apikey"):
         misperrors["error"] = "IPRep api key is missing"
         return misperrors
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** IPRep now returns its own "api key is missing" error instead of crashing or querying with a null key.

- **Problem** — The handler guard in `expansion/iprep.py` uses `and` to join "no config" and "no apikey", so it only fires when both are true and catches neither real failure: a missing config raises `KeyError: 'config'`, and a config lacking `apikey` slips through and sends a request to `packetmail.net` with `apikey=None`.
- **Fix** — Changes the operator to `or` so the existing "IPRep api key is missing" error is returned before any request is made.
- **Effect** — Analysts running IPRep without a key get the intended message instead of a traceback or a silent null-key lookup.
<!-- /bluf -->

The config guard in `iprep.py`'s handler used `and` instead of `or` to join its two failure conditions:

```python
if not request.get("config") and not request["config"].get("apikey"):
    misperrors["error"] = "IPRep api key is missing"
    return misperrors
```

With `and`, the guard only fires when *both* conditions are true, so neither real failure case is actually caught:

- If `config` is missing entirely, `not request.get("config")` is `True` but `not request["config"].get("apikey")` immediately raises `KeyError: 'config'` since `request["config"]` doesn't exist — the module crashes instead of returning the intended error.
- If `config` is present but has no `apikey`, `not request.get("config")` is `False`, so the `and` short-circuits to `False` and the guard never fires. The module proceeds to call `packetmail.net` with `apikey=None`, as if the lookup were valid.

**Impact:** an analyst running the IPRep expansion module without an API key configured either gets an unhandled exception instead of a clear "api key is missing" error, or — if a config block exists but is incomplete — gets a silent request to packetmail.net with a null key rather than the expected error message, obscuring the real cause of a failed enrichment.

**Fix:** changed the operator from `and` to `or`, so either condition (no config, or a config without an apikey) correctly returns the existing "IPRep api key is missing" error before any request is made. One-character change, no other edits, no behaviour change beyond restoring the guard's intended effect.

### Verification

- `flake8` on `misp_modules/modules/expansion/iprep.py`: clean, no output.
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 119.73s (0:01:59)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

