### PR TITLE
[high] fix: [goamlexport] reject an incomplete configuration instead of exporting None

### DIFF
--- a/misp_modules/modules/export_mod/goamlexport.py
+++ b/misp_modules/modules/export_mod/goamlexport.py
@@ -309,7 +309,7 @@ def handler(q=False):
     request = json.loads(q)
     if "data" not in request:
         return False
-    if not request.get("config") and not request["config"].get("rentity_id"):
+    if not request.get("config") or not request["config"].get("rentity_id"):
         misperrors["error"] = "Configuration error."
         return misperrors
     config = request["config"].get("rentity_id")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An incomplete goAML configuration is now rejected instead of exporting a `None` reporting entity.

- **Problem** — The configuration guard in `goamlexport.py` joins its two failure conditions with `and` instead of `or`, so neither case is caught: a missing config block raises `KeyError` on `request["config"]`, and a config without `rentity_id` short-circuits past the guard entirely.
- **Fix** — Changes the operator at line 312 so either condition returns the intended "Configuration error." response.
- **Effect** — Analysts exporting an event to goAML with an incomplete config get a clear error instead of an unhandled crash or a "successful" export carrying `<rentity_id>None</rentity_id>` in a report destined for a financial intelligence unit.
<!-- /bluf -->

The goAML export module's config guard used the wrong boolean operator:

```python
if not request.get("config") and not request["config"].get("rentity_id"):
    misperrors["error"] = "Configuration error."
    return misperrors
```

With `and`, both operands must be true to reject the request. That breaks in two ways:

- No config at all: `not request.get("config")` is `True`, but evaluation continues to `not request["config"].get("rentity_id")`, which does `request["config"].get(...)` on a missing/`None` config and raises `KeyError`.
- A config present but missing `rentity_id`: the first operand is `False`, so the whole condition short-circuits to `False`, the guard is skipped, and the export proceeds with a `None` reporting entity — emitting `<rentity_id>None</rentity_id>` into the produced goAML XML.

### Impact

An analyst exporting a MISP event to goAML with an incomplete module configuration either hits an unhandled `KeyError`, or — worse — gets a "successful" export containing `<rentity_id>None</rentity_id>`, a malformed reporting-entity field in a report meant for submission to a financial intelligence unit.

### Fix

Changed `and` to `or` at line 312 so either missing-config or missing-`rentity_id` correctly short-circuits to the intended `"Configuration error."` response, matching the equivalent fix in finding #25.

### Verification

- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/export_mod/goamlexport.py` — clean, no output
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 113.35s (0:01:53)`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

