### PR TITLE
[high] fix: [backscatter_io] accept ip-dst-only requests and reject empty ones

### DIFF
--- a/misp_modules/modules/expansion/backscatter_io.py
+++ b/misp_modules/modules/expansion/backscatter_io.py
@@ -46,11 +46,11 @@ def check_query(request):
             continue
         misperrors["error"] = "Backscatter.io authentication is missing."
         return output
-    if not request.get("ip-src") and request.get("ip-dst"):
+    if not request.get("ip-src") and not request.get("ip-dst"):
         misperrors["error"] = "Unsupported attributes type."
         return output
     profile = {"success": True, "config": config, "playbook": "generic"}
-    if "ip-src" in request:
+    if request.get("ip-src"):
         profile.update({"value": request.get("ip-src")})
     else:
         profile.update({"value": request.get("ip-dst")})


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Backscatter.io enrichment now works for `ip-dst`-only requests and rejects empty ones.

- **Problem** — `check_query` in `backscatter_io.py` bails out on `not request.get("ip-src") and request.get("ip-dst")`, rejecting exactly the valid `ip-dst`-only case, while a request with neither attribute falls through and queries the API with `value=None`; the following `if "ip-src" in request` also lets an empty `ip-src` key shadow a populated `ip-dst`.
- **Fix** — Negates the second half of the guard and switches the value-selection test to `request.get("ip-src")`.
- **Effect** — Analysts enriching an `ip-dst` attribute get results instead of "Unsupported attributes type", and empty requests fail cleanly.
<!-- /bluf -->

The input guard in `check_query` was inverted, so it silently mishandled valid enrichment requests:

```python
if not request.get("ip-src") and request.get("ip-dst"):
    misperrors["error"] = "Unsupported attributes type."
    return output
profile = {"success": True, "config": config, "playbook": "generic"}
if "ip-src" in request:
    profile.update({"value": request.get("ip-src")})
else:
    profile.update({"value": request.get("ip-dst")})
```

The condition only bails out when `ip-src` is absent **and** `ip-dst` is present — i.e. it rejects the exact case it should support (a valid `ip-dst`-only request), while a request with *neither* attribute falls through the guard entirely and reaches `profile["value"] = request.get("ip-dst")`, which resolves to `None`. Separately, `if "ip-src" in request` treats an empty/falsy `ip-src` key as present, shadowing a perfectly good `ip-dst` value.

**Impact:** An analyst enriching an `ip-dst` attribute with the Backscatter.io module gets `Unsupported attributes type` even though `ip-dst` is a supported attribute type for this module, and a malformed request (no IP at all) proceeds to query the API with `value=None` instead of failing cleanly.

**Fix:** Negate the second half of the guard (`and not request.get("ip-dst")`) so it only rejects requests where both are absent, and switch the value-selection check to `request.get("ip-src")` so an empty `ip-src` no longer masks a populated `ip-dst`. Purely a bug fix — no behaviour change beyond making `ip-dst`-only requests work as intended.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification
- `flake8` on the changed file: clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 105.43s (0:01:45)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

