### PR TITLE
[medium] fix: [anyrun_sandbox_import] require both API key and analysis UUID

### DIFF
--- a/misp_modules/modules/import_mod/anyrun_sandbox_import.py
+++ b/misp_modules/modules/import_mod/anyrun_sandbox_import.py
@@ -72,7 +72,7 @@ def handler(q=False):
         token = request.get("config").get("api_key")
         analysis_uuid = request.get("config").get("ANYRUN Analysis UUID")
 
-        if not any((token, analysis_uuid)):
+        if not all((token, analysis_uuid)):
             raise RunTimeException("ANY.RUN API-KEY and Analysis UUID must be specified.")
 
         with SandboxConnector.windows(token, integration=Config.INTEGRATION) as connector:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A half-configured ANY.RUN import module now fails with its own clear error message.

- **Problem** — The config guard in `anyrun_sandbox_import.py` uses `if not any((token, analysis_uuid))`, which only fires when both values are missing, so a module configured with just the API key or just the Analysis UUID passes a `None` into `SandboxConnector.windows()` and the downstream parser.
- **Fix** — Changes `any` to `all` so the guard matches its own error message, which already states that both must be specified.
- **Effect** — A misconfigured module fails with the clear "API-KEY and Analysis UUID must be specified" message instead of an opaque error from the ANY.RUN SDK.
<!-- /bluf -->

The config guard in `anyrun_sandbox_import.py` used `any()` instead of `all()`:

```python
token = request.get("config").get("api_key")
analysis_uuid = request.get("config").get("ANYRUN Analysis UUID")

if not any((token, analysis_uuid)):
    raise RunTimeException("ANY.RUN API-KEY and Analysis UUID must be specified.")
```

`not any((token, analysis_uuid))` is only true when **both** values are missing, so supplying just one of the two lets a `None` flow straight into `SandboxConnector.windows(token, ...)` and the downstream parser. This contradicts the module's own error message, which says both values "must be specified."

**Impact on a MISP user:** a user who misconfigures the module with only the API key (or only the Analysis UUID) set does not get the clear "API-KEY and Analysis UUID must be specified" message. Instead the request fails later with an opaque error from the ANY.RUN SDK or parser, making misconfiguration much harder to diagnose.

**Fix:** changed `any` to `all`, so the guard now raises whenever either value is missing, matching the error message's stated requirement. This is a one-token change with no other behavior impact.

No security default or contract was changed — this only makes an existing validation check match its own documented intent.

### Verification
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/` on the changed file: clean, no output.
- Module test suite: 161 passed, 4 skipped, 5 subtests passed in 108.79s (0:01:48).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

