### PR TITLE
fix: [cuckooimport] default the network section to a dict

### DIFF
--- a/misp_modules/modules/import_mod/cuckooimport.py
+++ b/misp_modules/modules/import_mod/cuckooimport.py
@@ -343,7 +343,7 @@ class CuckooParser:
 
     def add_http(self):
         """Add the HTTP requests"""
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         http = network.get("http", [])
         if not http:
             log.info("No HTTP connection found in the report, skipping")
@@ -363,7 +363,7 @@ class CuckooParser:
         Add UDP/TCP traffic
         proto must be one of "tcp", "udp"
         """
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         li_conn = network.get(proto, [])
         if not li_conn:
             log.info(f"No {proto} connection found in the report, skipping")
@@ -394,7 +394,7 @@ class CuckooParser:
 
     def add_dns(self):
         """Add DNS records"""
-        network = self.report.get("network", [])
+        network = self.report.get("network", {})
         dns = network.get("dns", [])
         if not dns:
             log.info("No DNS connection found in the report, skipping")


### PR DESCRIPTION
### Defect

In `misp_modules/modules/import_mod/cuckooimport.py`, three sites in `CuckooParser` fetch the `network` section with a list default, then immediately call `.get()` on it as if it were a dict:

```python
network = self.report.get("network", [])
http = network.get("http", [])   # AttributeError: 'list' object has no attribute 'get'
```

(same pattern at `add_http` line 346, `add_connections` line 366, and `add_dns` line 397)

When a Cuckoo report has no `"network"` key at all — a legitimate case, e.g. a static analysis or a sample with no observed network activity — `self.report.get("network", [])` returns `[]`, and the subsequent `.get(proto, [])` / `.get("http", [])` / `.get("dns", [])` call raises `AttributeError: 'list' object has no attribute 'get'`.

### Impact

The exception propagates out of `CuckooParser`, aborting the entire Cuckoo report import in MISP. An analyst uploading a Cuckoo report that lacks a `network` section gets a hard failure instead of an import that simply skips the network-derived indicators (HTTP requests, TCP/UDP connections, DNS records) and logs "no connection found, skipping" as the code clearly intends.

### Fix

Changed the default from `[]` to `{}` at all three call sites, so a missing `network` key resolves to an empty dict, `.get(...)` on it returns `[]` as intended, and the existing "no X connection found, skipping" log path runs instead of raising.

No behaviour change beyond restoring the intended skip path — the rest of each method is untouched.

### Verification

- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/import_mod/cuckooimport.py` — clean, no output.
- Full test suite: 161 passed, 4 skipped, 5 subtests passed in 118.89s (0:01:58).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
