### PR TITLE
[high] fix: [email_import] filter HTML link targets before collecting them

### DIFF
--- a/misp_modules/modules/import_mod/email_import.py
+++ b/misp_modules/modules/import_mod/email_import.py
@@ -381,9 +381,9 @@ class HTMLURLParser(HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         if tag == "a":
-            value = self.urls.append(dict(attrs).get("href"))
-        if tag == "img":
-            value = self.urls.append(dict(attrs).get("src"))
+            value = dict(attrs).get("href")
+        elif tag == "img":
+            value = dict(attrs).get("src")
         else:
             return
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Imported emails now yield a clean list of HTTP(S) links instead of every unfiltered link target.

- **Problem** — `HTMLURLParser.handle_starttag` in `email_import.py` assigns `value` from `list.append()`, which always returns `None`, so the http/https scheme check below is dead code, and the `img` branch uses a bare `if` so `a` tags fall straight through the `else: return`. Every `href` and `src` is appended unfiltered, including `cid:`, `mailto:`, `javascript:` and `None`.
- **Fix** — Assigns the attribute value directly and fixes the branch structure so the existing scheme filter runs.
- **Effect** — Analysts get only HTTP(S) links, without the noise that could also raise exceptions when `URLObject()` is built from a `None` or non-URL string.
<!-- /bluf -->

The `email_import` module's HTML link collector never actually filtered anything, because of two independent bugs in `HTMLURLParser.handle_starttag`:

```python
def handle_starttag(self, tag, attrs):
    if tag == "a":
        value = self.urls.append(dict(attrs).get("href"))
    if tag == "img":
        value = self.urls.append(dict(attrs).get("src"))
    else:
        return

    # avoid references like internal cid:
    if value and value.lower().startswith(("http://", "https://")):
        self.urls.append(value)
```

1. `value` is assigned the return value of `list.append(...)`, which is always `None`. The subsequent scheme check (`value.lower().startswith(("http://", "https://"))`) is therefore permanently dead code — `value` is `None`, so the `if value` guard short-circuits and the check never runs.
2. The `img` branch uses a bare `if` instead of `elif`, so the `else: return` only pairs with the `img` test. For an `a` tag, execution falls straight through into the (dead) scheme check below.

Net effect: every `href`/`src` on every `a`/`img` tag is appended to `self.urls` unconditionally and unfiltered, including `cid:`, `mailto:`, `javascript:`, and `None` values, before being handed to `URLObject()` downstream.

**Impact:** An analyst importing an email through this module gets a URL attribute list polluted with non-HTTP references (internal `cid:` attachment references, `mailto:` addresses, `javascript:` pseudo-links) and can hit exceptions or malformed attributes when `URLObject()` is constructed from a `None` or non-URL string — noise and potential failures in what should be a clean list of externally-reachable links extracted from the email body.

**Fix:** Assign the attribute value directly (`dict(attrs).get(...)`) instead of the result of `.append()`, and chain the `img` test with `elif` so the early `return` covers both the `a` and `img`/other-tag cases. This lets the existing `http://`/`https://` scheme check gate the single, now-reachable `self.urls.append(value)` call.

No behaviour change beyond restoring the module's intended filtering — the http/https scheme check already existed in the code and was simply never reachable.

### Verification

- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/` on the changed file: clean, no output.
- Full test suite: 161 passed, 4 skipped, 5 subtests passed in 101.88s (0:01:41), matching baseline.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

