### PR TITLE
[high] fix: [threatanalyzer_import] parse modified_files mapping.log defensively

### DIFF
--- a/misp_modules/modules/import_mod/threatanalyzer_import.py
+++ b/misp_modules/modules/import_mod/threatanalyzer_import.py
@@ -64,11 +64,13 @@ def handler(q=False):
                                 continue
                             if line.count("|") == 3:
                                 l_fname, l_size, l_md5, l_created = line.split("|")
-                            if line.count("|") == 4:
+                            elif line.count("|") == 4:
                                 l_fname, l_size, l_md5, l_sha256, l_created = line.split("|")
+                            else:
+                                continue
                             l_fname = cleanup_filepath(l_fname)
                             if l_fname:
-                                if l_size == 0:
+                                if int(l_size) == 0:
                                     results.append(
                                         {
                                             "values": l_fname,


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** One malformed `mapping.log` line no longer kills an entire ThreatAnalyzer import.

- **Problem** — In `threatanalyzer_import.py` the `mapping.log` loop binds `l_fname` only inside two `if` branches testing for exactly 3 or 4 pipe characters, so any other pipe count raises `UnboundLocalError` and aborts the whole import rather than skipping one line; separately `if l_size == 0` compares a string from `str.split()` to an int and is dead, so zero-byte dropped files were queued as malware samples.
- **Fix** — Makes the second check an `elif` with a trailing `else: continue`, and wraps the size comparison in `int()`.
- **Effect** — Lines with an unexpected pipe count are skipped instead of failing the import, and zero-length dropped files are reported as filename attributes.
<!-- /bluf -->

In the `mapping.log` pre-processing loop, `l_fname`/`l_size`/`l_md5` were only bound inside two `if` branches that test for exactly 3 or 4 pipe characters:

```python
if line.count("|") == 3:
    l_fname, l_size, l_md5, l_created = line.split("|")
if line.count("|") == 4:
    l_fname, l_size, l_md5, l_sha256, l_created = line.split("|")
l_fname = cleanup_filepath(l_fname)
if l_fname:
    if l_size == 0:
```

Any other pipe count (a malformed or unexpected line in `mapping.log`) leaves `l_fname` unbound and raises `UnboundLocalError`, which aborts the entire ThreatAnalyzer import — not just that one line. Separately, `l_size` comes straight out of `str.split()`, so it is always a `str`; `if l_size == 0:` is comparing a string to an int and is always `False`, so the branch that reports zero-length dropped files as filename attributes is dead code, and those files were instead queued as malware samples.

**Impact:** an analyst importing a ThreatAnalyzer report with even one line in `mapping.log` that doesn't split into exactly 3 or 4 fields gets a hard failure and no import at all, instead of that single line being skipped. Zero-byte dropped files are also silently mis-classified as sample attributes rather than filename attributes.

**Fix:** made the second pipe-count check an `elif` with a trailing `else: continue`, so lines with any other pipe count are skipped instead of crashing the import. Wrapped the size comparison in `int(l_size)` so zero-length files are correctly reported as filename attributes.

No behaviour change beyond fixing these two bugs — malformed lines are now skipped (matching the surrounding loop's existing skip-and-continue pattern for other malformed input) instead of crashing the whole import, and zero-length dropped files are now correctly reported.

### Verification

- `flake8` on the changed file: clean (no output).
- Full module test suite against a local server on port 6731: 161 passed, 4 skipped, 5 subtests passed in 108.91s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

