### PR TITLE
[high] fix: [liteexport] export every event instead of only the last one

### DIFF
--- a/misp_modules/modules/export_mod/liteexport.py
+++ b/misp_modules/modules/export_mod/liteexport.py
@@ -50,10 +50,11 @@ def handler(q=False):
         return False
 
     # ~ Misp json structur
-    liteEvent = {"Event": {}}
+    liteEvents = []
 
     for evt in request["data"]:
         rawEvent = evt["Event"]
+        liteEvent = {"Event": {}}
         liteEvent["Event"]["info"] = rawEvent["info"]
         liteEvent["Event"]["Attribute"] = []
 
@@ -66,10 +67,12 @@ def handler(q=False):
                 liteAttr["value"] = attr["value"]
                 liteEvent["Event"]["Attribute"].append(liteAttr)
 
+        liteEvents.append(liteEvent)
+
     return {
         "response": [],
         "data": str(
-            base64.b64encode(bytes(json.dumps(liteEvent, indent=config["indent_json_export"]), "utf-8")),
+            base64.b64encode(bytes(json.dumps(liteEvents, indent=config["indent_json_export"]), "utf-8")),
             "utf-8",
         ),
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Lite Export now returns every requested event instead of silently keeping only the last one.

- **Problem** — `liteexport.py` allocates one `liteEvent` dictionary before the loop over `request["data"]` and merely resets its fields on each iteration, then serialises it after the loop, so a multi-event export silently returns only the last event with no error or warning.
- **Fix** — Builds a fresh dictionary per event, collects them in a `liteEvents` list, and serialises that list.
- **Effect** — Exports contain every requested event rather than one, so an analyst no longer loses most of the exported attributes without any indication.
- **Cost** — The output shape necessarily becomes a JSON array, including for single-event exports; nothing in-repo parses the old shape.
<!-- /bluf -->

The Lite Export module allocates a single `liteEvent` dictionary before the loop over events, then resets its fields on every iteration:

```python
liteEvent = {"Event": {}}

for evt in request["data"]:
    rawEvent = evt["Event"]
    liteEvent["Event"]["info"] = rawEvent["info"]
    liteEvent["Event"]["Attribute"] = []
    ...
return {..., "data": ... base64.b64encode(bytes(json.dumps(liteEvent, ...)))}
```

Because `liteEvent` is shared across iterations and only its final state is serialised after the loop, a multi-event export silently discards every event except the last one — no error or warning is raised.

**Impact:** An analyst exporting several MISP events at once via the Lite Export module gets back a JSON payload that looks valid but only contains one event's data. Depending on the query that produced `request["data"]`, this can mean losing most of the exported attributes without any indication that data was dropped.

**Fix:** Build a fresh `liteEvent` dictionary inside the loop for each event, append it to a `liteEvents` list, and serialise that list instead. This necessarily changes the output shape from a single event object to a JSON array of events — including for single-event exports, since there is no way to distinguish the "one event" and "many events" cases without an ambiguous conditional format. No tests or other code in this repository parse this module's output format, so nothing in-repo depends on the old shape.

### Verification
- `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/export_mod/liteexport.py`: clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 66.21s (0:01:06)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

