### PR TITLE
[high] fix: [shodan] pass the ssl cert dict to _parse_cert on the vulns branch

### DIFF
--- a/misp_modules/modules/expansion/shodan.py
+++ b/misp_modules/modules/expansion/shodan.py
@@ -131,7 +131,7 @@ class ShodanParser:
                             vulnerabilities[cve] = vulnerability
                 # Also parse the certificates
                 if data.get("ssl"):
-                    self._parse_cert(data["ssl"])
+                    self._parse_cert(data["ssl"]["cert"])
             for cve, vulnerability in vulnerabilities.items():
                 vulnerability_object = MISPObject("vulnerability")
                 vulnerability_object.add_attribute(**{"type": "vulnerability", "object_relation": "id", "value": cve})


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `shodan.py` passes the wrong dict to `_parse_cert`, emitting an empty `x509` on the vulns branch.

- **Problem** — In `_parse_ssl_data`, the vulns branch at line 134 calls `self._parse_cert(data["ssl"])` instead of the nested cert sub-object, so every certificate field lookup misses and an empty `x509` object is emitted; the sibling no-vulns branch at line 163 already passes `data["ssl"]["cert"]` correctly.
- **Fix** — Changes the one call to match the correct sibling.
- **Effect** — Analysts enriching a host that returns both SSL data and known CVEs will get the real serial number, signature algorithm, issuer and subject instead of a blank `x509` object.
<!-- /bluf -->

### The defect

```python
# _parse_ssl_data (vulns branch), misp_modules/modules/expansion/shodan.py:134
if data.get("ssl"):
    self._parse_cert(data["ssl"])
```

`_parse_cert` reads certificate fields (`serial`, `sig_alg`, `issuer`, `subject`, etc.) directly off the dict it is given, expecting the nested `cert` sub-object. Here it is handed the outer `ssl` dict instead, so every field lookup misses and the method silently builds an empty `x509` MISP object. The sibling branch a few lines down (the no-vulns path, line 163) already does this correctly: `self._parse_cert(data["ssl"]["cert"])`.

### Impact

When a Shodan host lookup returns both SSL certificate data and known vulnerabilities, the module currently emits an empty `x509` object into the MISP event instead of the certificate's actual serial number, signature algorithm, issuer, and subject. An analyst enriching an indicator with Shodan data loses the certificate details whenever the host also has CVEs attached — precisely the hosts most worth inspecting closely.

### The fix

Changed line 134 to pass `data["ssl"]["cert"]` instead of `data["ssl"]`, matching the correct sibling call at line 163. One-line change, no behaviour change beyond producing correct (non-empty) certificate attributes.

### Verification

- `flake8 misp_modules/modules/expansion/shodan.py` — clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 104.19s (0:01:44)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

