### PR TITLE
[high] fix: [nextcloud_talk] report failed message delivery instead of success

### DIFF
--- a/misp_modules/modules/action_mod/nextcloud_talk.py
+++ b/misp_modules/modules/action_mod/nextcloud_talk.py
@@ -95,23 +95,23 @@ def createPost(request):
 
     try:
         # Make POST request to send message
-        requests.post(
+        response = requests.post(
             endpoint,
             headers=headers,
             auth=(params["nextcloud_app_uuid_login"], params["app_access_token"]),
             json=message_data
         )
+        response.raise_for_status()
         return True
     except requests.exceptions.RequestException:
-        return True
+        return False
 
 
 def handler(q=False):
     if q is False:
         return False
     request = json.loads(q)
-    createPost(request)
-    r = {"data": True}
+    r = {"data": createPost(request)}
     return r
 
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `createPost()` in the nextcloud_talk module reports success even when the message never arrives.

- **Problem** — `createPost()` returns `True` from both the try and the except branch, and `requests.post()` does not raise on 4xx/5xx, so a bad token, wrong conversation ID, outage or timeout all read as a delivered notification; `handler()` then discarded the return value entirely and hardcoded `{"data": True}`.
- **Fix** — Adds `response.raise_for_status()`, returns `False` from the except branch, and propagates the boolean through `handler()`.
- **Effect** — Failed Nextcloud Talk alerts now surface as `{"data": False}`, the same success/failure shape the `mattermost` and `slack` action modules already use.
<!-- /bluf -->

The delivery-status branch in `createPost()` reported success on failure:

```python
    try:
        # Make POST request to send message
        requests.post(
            endpoint,
            headers=headers,
            auth=(params["nextcloud_app_uuid_login"], params["app_access_token"]),
            json=message_data
        )
        return True
    except requests.exceptions.RequestException:
        return True
```

`requests.post()` does not raise on HTTP error status codes (4xx/5xx), so a bad token or wrong conversation ID never entered the `except` branch at all, and even when it did — unreachable server, DNS failure, TLS error, timeout — the handler still returned `True`. `handler()` compounded this by discarding `createPost()`'s return value entirely and hardcoding `{"data": True}`, so returning `False` from `createPost()` would have been a no-op.

**Impact:** a MISP analyst configuring this action module to push alerts to a Nextcloud Talk channel gets no indication when a notification silently fails to reach the channel — network outage, expired token, or wrong room ID all read as "delivered" in MISP.

**Fix:** `response.raise_for_status()` was added so a non-2xx HTTP response (e.g. bad credentials) raises and is caught; the `except` branch now returns `False` instead of `True`; and `handler()` now propagates `createPost()`'s boolean into `{"data": ...}` instead of discarding it.

**Behaviour change:** `handler()`'s output for this module can now be `{"data": False}`, where it was previously always `{"data": True}`. This is not a new contract — `{"data": <bool>}` is the existing return shape used by the other action modules (e.g. `mattermost.py`, `slack.py`) to signal delivery success/failure — nextcloud_talk.py just wasn't honoring it.

### Verification

- `flake8 misp_modules/modules/action_mod/nextcloud_talk.py` — clean
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 105.75s (0:01:45)`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

