### PR TITLE
[high] fix: [recordedfuture] stop clobbering galaxy tags in relatedEntities loop

### DIFF
--- a/misp_modules/modules/expansion/recordedfuture.py
+++ b/misp_modules/modules/expansion/recordedfuture.py
@@ -406,7 +406,6 @@ class RFEnricher:
                                 self.add_attribute(indicator, related_type)
                     elif related_type in self.galaxy_tag_types:
                         # Related entities added as galaxy-tags to the enriched attribute
-                        galaxy_tags = []
                         for related in related_entity["entities"]:
                             # filter those entities that have count bigger than 4, to reduce noise
                             # because there can be a huge list of related entities


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `handle_related_entities` re-initialises `galaxy_tags` in its loop, losing all but the last group.

- **Problem** — `RFEnricher.handle_related_entities` in `recordedfuture.py` re-initialises the `galaxy_tags` accumulator inside the loop over `relatedEntities` groups, discarding every tag collected by earlier groups, so only the last matching group's tags survive to the `add_tag` call after the loop.
- **Fix** — Deletes the redundant re-initialisation, leaving the single initialisation before the loop.
- **Effect** — Analysts on Recorded Future tokens without the "links" module will now get the full set of threat-actor and malware galaxy tags on enriched attributes instead of silently losing all but the last group.
<!-- /bluf -->

Inside `RFEnricher.handle_related_entities` (called for the `relatedEntities` fallback path when a MISP user's Recorded Future token lacks the "links" module), the galaxy-tag branch re-initialised the accumulator on every loop iteration:

```python
for related_entity in response["data"]["relatedEntities"]:
    ...
    elif related_type in self.galaxy_tag_types:
        # Related entities added as galaxy-tags to the enriched attribute
        galaxy_tags = []          # <-- wipes out everything collected so far
        for related in related_entity["entities"]:
            ...
            if galaxy and galaxy not in galaxy_tags:
                galaxy_tags.append(galaxy)
for galaxy in galaxy_tags:
    self.add_tag(galaxy)
```

`galaxy_tags` is already initialised once before the outer loop. Re-initialising it inside each matching `related_entity` group discards galaxy tags gathered from every earlier group, so only the last matching group's tags ever survive to reach the `add_tag` call after the loop.

### Impact

An analyst enriching an attribute with the Recorded Future module (on tokens without the "links" module enabled) silently loses galaxy tags for every related-entity group except the last one processed. The enrichment appears to succeed, but the resulting MISP event is missing threat-actor/malware/etc. galaxy tags an analyst would reasonably expect and rely on for triage and correlation.

### Fix

Removed the redundant `galaxy_tags = []` re-initialisation inside the branch, so tags accumulate correctly across all related-entity groups before being applied via `add_tag`. Pure bugfix — no behaviour contract change.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `flake8 misp_modules/modules/expansion/recordedfuture.py` — clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 75.68s (0:01:15)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

