### PR TITLE
[medium] fix: [convert_markdown_to_pdf] fix broken config membership check for margin

### DIFF
--- a/misp_modules/modules/expansion/convert_markdown_to_pdf.py
+++ b/misp_modules/modules/expansion/convert_markdown_to_pdf.py
@@ -200,9 +200,9 @@ def handler(q=False):
     markdown = data.get("markdown")
     try:
         margin = "3"
-        if "config" in request.get("config", []):
-            if request["config"].get("margin"):
-                margin = request["config"].get("margin")
+        cfg = request.get("config") or {}
+        if cfg.get("margin"):
+            margin = cfg.get("margin")
         rendered = convert(markdown, margin=margin)
     except Exception as e:
         rendered = f"Error: {e}"


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A broken config membership check means the admin-configured PDF margin is never read.

- **Problem** — `convert_markdown_to_pdf.py` guards its margin option with `if "config" in request.get("config", [])`, which tests for a literal `"config"` key inside the config dict itself and is therefore always False.
- **Fix** — Replaces the check with `cfg = request.get("config") or {}` and reads `cfg.get("margin")` from it.
- **Effect** — A MISP admin who sets a custom margin will now actually get it applied instead of every PDF silently falling back to the hardcoded default of `"3"`.
<!-- /bluf -->

The margin config check in `convert_markdown_to_pdf.py` is broken:

```python
if "config" in request.get("config", []):
    if request["config"].get("margin"):
        margin = request["config"].get("margin")
```

This tests whether the literal string `"config"` is a key inside the `config` dict itself, which is never the case — it always evaluates to `False`. As a result, the admin-configured `margin` value is never read, and the PDF is always rendered with the hardcoded default margin (`"3"`), silently ignoring the module's own configuration option.

**Impact:** A MISP admin who sets a custom `margin` value for this module gets no effect — every markdown-to-PDF conversion silently falls back to the default margin, with no error or indication that the configured value was ignored.

**Fix:** Replace the broken membership check with `cfg = request.get("config") or {}` followed by `if cfg.get("margin"): margin = cfg.get("margin")`, so the configured margin is actually read when present.

No behaviour change beyond making the existing config option work as documented; no new default was introduced.

### Verification

- `flake8` on the changed file: clean (no output)
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 78.65s (0:01:18)`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

