### PR TITLE
[critical] fix: [qrcode] validate every redirect hop against the SSRF check

### DIFF
--- a/misp_modules/modules/expansion/qrcode.py
+++ b/misp_modules/modules/expansion/qrcode.py
@@ -9,7 +9,7 @@ import json
 import re
 import socket
 import ipaddress
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 # Third-party imports
 # pylint: disable=import-error
@@ -52,6 +52,7 @@ MODULE_CONFIG = []
 # --- SECURITY CONFIGURATION ---
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB limit (Anti-DoS)
 TIMEOUT_SECONDS = 10
+MAX_REDIRECTS = 5
 
 
 def is_safe_url(url):
@@ -95,26 +96,39 @@ def fetch_url_image(target_url):
         headers = {'User-Agent': user_agent}
 
         # 2. Secure Download (Stream + Size Limit)
-        # pylint: disable=missing-timeout
-        with requests.get(
-            target_url,
-            headers=headers,
-            timeout=TIMEOUT_SECONDS,
-            stream=True
-        ) as response:  # nosec
-            response.raise_for_status()
+        # Redirects are followed manually so every hop passes the SSRF check
+        current_url = target_url
+        for _ in range(MAX_REDIRECTS + 1):
+            # pylint: disable=missing-timeout
+            with requests.get(
+                current_url,
+                headers=headers,
+                timeout=TIMEOUT_SECONDS,
+                stream=True,
+                allow_redirects=False
+            ) as response:  # nosec
+                if response.is_redirect and 'location' in response.headers:
+                    current_url = urljoin(current_url, response.headers['location'])
+                    is_safe, msg = is_safe_url(current_url)
+                    if not is_safe:
+                        return None, f"Security Block (SSRF Protection): {msg}"
+                    continue
 
-            if 'content-length' in response.headers:
-                if int(response.headers['content-length']) > MAX_IMAGE_SIZE:
-                    return None, 'Image too large (DoS protection).'
+                response.raise_for_status()
 
-            content = b""
-            for chunk in response.iter_content(chunk_size=8192):
-                content += chunk
-                if len(content) > MAX_IMAGE_SIZE:
-                    return None, 'Image too large (DoS protection) - Download aborted.'
+                if 'content-length' in response.headers:
+                    if int(response.headers['content-length']) > MAX_IMAGE_SIZE:
+                        return None, 'Image too large (DoS protection).'
 
-        return np.frombuffer(content, np.uint8), None
+                content = b""
+                for chunk in response.iter_content(chunk_size=8192):
+                    content += chunk
+                    if len(content) > MAX_IMAGE_SIZE:
+                        return None, 'Image too large (DoS protection) - Download aborted.'
+
+            return np.frombuffer(content, np.uint8), None
+
+        return None, 'Too many redirects.'
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         return None, f"Fetch Error: {str(e)}"


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The qrcode module's SSRF check is bypassed by redirects; this PR validates every hop.

- **Problem** — `fetch_url_image()` runs its `is_safe_url()` check against the initial target only, then calls `requests.get` with default redirect following, so a 302 pointing at `127.0.0.1`, a link-local address or a cloud metadata endpoint is followed with the check never re-applied.
- **Fix** — Sets `allow_redirects=False`, resolves each `Location` header with `urljoin`, re-validates it with `is_safe_url()` before the next hop, and caps the chain at `MAX_REDIRECTS` of 5.
- **Effect** — The redirect-based bypass is closed for analysts running the module against attacker-influenced URLs.
- **Cost** — The separate DNS-rebinding gap between check and connect remains open, as the PR notes.
<!-- /bluf -->

`fetch_url_image()` in the qrcode module validated the target URL up front with `is_safe_url()`, but then handed the request to `requests.get(..., stream=True)` with default redirect-following behaviour:

```python
with requests.get(
    target_url,
    headers=headers,
    timeout=TIMEOUT_SECONDS,
    stream=True
) as response:  # nosec
    response.raise_for_status()
    ...
```

`is_safe_url()` only ever sees `target_url`. If the server at that URL responds with a `302 Location: http://127.0.0.1:6379/` (or any other internal/loopback/link-local address), `requests` transparently follows it and the SSRF check is never re-applied to the redirect target — the check is bypassed entirely.

**Impact:** an analyst who runs the `qrcode` expansion module against an attacker-controlled or attacker-influenced URL can be made to have MISP itself issue a request to an internal-only service (a Redis instance, a cloud metadata endpoint, an internal admin panel, etc.) from the MISP server's network position, defeating the SSRF protection the module already tries to provide.

**Fix:** the request now uses `allow_redirects=False`. Each 3xx response's `Location` header is resolved against the current URL with `urljoin` and re-validated with `is_safe_url()` before the next hop is followed, with the chain capped at a new `MAX_REDIRECTS` (5) to avoid an unbounded loop. The streaming download and size-limit logic are unchanged and only run once a final, non-redirect response is reached.

Note: this closes the redirect-bypass path demonstrated above (the concrete finding). `is_safe_url()` still resolves DNS once per hop and `requests` resolves again when it opens the connection, so a DNS-rebinding attack (where the name resolves safely at check time but to an internal address at connect time) is not addressed here — closing that fully would need pinning the checked IP via a custom transport adapter, which is a larger change than this fix.

No behaviour change for legitimate fetches: a normal, non-redirecting image URL is fetched exactly as before.

### Verification

- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 84.79s (0:01:24)`
- Lint: `flake8 --extend-exclude=misp_modules/lib/,tests/,website/ misp_modules/modules/expansion/qrcode.py` — clean, no output

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

