### PR TITLE
[high] fix: [otx/threatcrowd] correct reversed blacklist membership check

### DIFF
--- a/misp_modules/modules/expansion/otx.py
+++ b/misp_modules/modules/expansion/otx.py
@@ -67,7 +67,7 @@ def isBlacklisted(value):
     ]
 
     for b in blacklist:
-        if value in b:
+        if value.startswith(b):
             return True
 
     return False

--- a/misp_modules/modules/expansion/threatcrowd.py
+++ b/misp_modules/modules/expansion/threatcrowd.py
@@ -62,7 +62,7 @@ def isBlacklisted(value):
     blacklist = ["8.8.8.8", "255.255.255.255", "192.168.56.", "time.windows.com"]
 
     for b in blacklist:
-        if value in b:
+        if value.startswith(b):
             return True
 
     return False


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A reversed membership test in `isBlacklisted()` leaves the otx/threatcrowd noise filter inert.

- **Problem** — The `isBlacklisted()` helper in `otx.py` and `threatcrowd.py` tests `value in b`, which asks whether the candidate indicator is a substring of the blacklist entry rather than the reverse. Exact entries match only by coincidence and the `192.168.56.` prefix entry can never match anything.
- **Fix** — The test is changed to `value.startswith(b)`.
- **Effect** — Filler values such as `192.168.56.101` from OTX pulses and ThreatCrowd resolutions are now suppressed as intended instead of being returned to the analyst as if they were real indicators.
<!-- /bluf -->

The `isBlacklisted()` helper in both modules has the membership test backwards:

```python
for b in blacklist:
    if value in b:
        return True
```

`value in b` checks whether the candidate `value` (an IP or hostname pulled from an OTX/ThreatCrowd response) is a *substring of the blacklist entry*, not the other way around. For an exact-match entry this only works when `value` happens to equal `b` (a lucky coincidence for `"8.8.8.8"`, `"255.255.255.255"`, `"time.windows.com"`), and for the prefix entry `"192.168.56."` it can never match at all, since no real IP or hostname is a substring of that seven-character string.

**Impact:** the internal-IP / test-network / noise-host filter is effectively inert. Values like `192.168.56.101` (the well-known Vagrant/VirtualBox NAT range used as filler noise in OTX pulses and ThreatCrowd resolutions) sail straight through and get returned to the analyst as if they were real indicators, polluting enrichment results with junk that the module was specifically written to suppress.

**Fix:** changed the check to `value.startswith(b)`, which correctly matches both the exact-string entries and the `"192.168.56."` prefix entry, restoring the intended filtering behaviour. This is a bug fix restoring documented/intended filtering, not a new security policy — no behaviour change beyond making the existing blacklist actually work.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification
- `flake8` on both changed files: clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 91.08s (0:01:31)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

