### PR TITLE
[high] fix: [threatfox] return misperrors on non-ok API responses

### DIFF
--- a/misp_modules/modules/expansion/threatfox.py
+++ b/misp_modules/modules/expansion/threatfox.py
@@ -58,7 +58,6 @@ def handler(q=False):
         return False
 
     request = json.loads(q)
-    ret_val = ""
 
     if not request.get('config') or not request['config'].get('auth_key'):
         return {'error': 'A auth key is required to access all abuse.ch API services.'}
@@ -73,23 +72,29 @@ def handler(q=False):
 
     data = {"query": "search_ioc", "search_term": f"{to_query}"}
     response = requests.post(API_URL, headers={'Auth-Key': request['config']['auth_key']}, data=json.dumps(data))
-    if response.status_code == 200:
-        result = json.loads(response.text)
-        if result["query_status"] == "ok":
-            confidence_tag = confidence_level_to_tag(result["data"][0]["confidence_level"])
-            ret_val = {
-                "results": [
-                    {
-                        "types": mispattributes["output"],
-                        "values": [result["data"][0]["threat_type_desc"]],
-                        "tags": [
-                            result["data"][0]["malware"],
-                            result["data"][0]["malware_printable"],
-                            confidence_tag,
-                        ],
-                    }
-                ]
+    if response.status_code != 200:
+        misperrors["error"] = f"ThreatFox API returned status code {response.status_code}"
+        return misperrors
+
+    result = json.loads(response.text)
+    if result["query_status"] != "ok":
+        misperrors["error"] = f"ThreatFox query status: {result['query_status']}"
+        return misperrors
+
+    confidence_tag = confidence_level_to_tag(result["data"][0]["confidence_level"])
+    ret_val = {
+        "results": [
+            {
+                "types": mispattributes["output"],
+                "values": [result["data"][0]["threat_type_desc"]],
+                "tags": [
+                    result["data"][0]["malware"],
+                    result["data"][0]["malware_printable"],
+                    confidence_tag,
+                ],
             }
+        ]
+    }
 
     return ret_val
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `threatfox.py` returns a bare empty string, not `misperrors`, unless the lookup is a clean hit.

- **Problem** — `handler()` initialises `ret_val` to an empty string and only reassigns it inside a doubly nested branch requiring both HTTP 200 and `query_status == "ok"`, so a non-200 response or a perfectly ordinary `"no_result"` answer returns a bare string to the dispatcher with no error surfaced.
- **Fix** — Both paths now return `misperrors` with a descriptive message giving the HTTP status or the ThreatFox `query_status`, leaving the success path untouched.
- **Effect** — Analysts querying an IOC with no match, or hitting rate limiting, now see why nothing came back.
<!-- /bluf -->

`threatfox.py`'s `handler()` initialized `ret_val` to an empty string and only ever
reassigned it inside a doubly-nested branch — status code 200 **and**
`query_status == "ok"`:

```python
ret_val = ""
...
if response.status_code == 200:
    result = json.loads(response.text)
    if result["query_status"] == "ok":
        ...
        ret_val = {
            "results": [...]
        }

return ret_val
```

Any other outcome — a non-200 HTTP status, or a 200 response with
`query_status` set to something like `"no_result"` — fell through both `if`s
and returned the bare string `""` to the module dispatcher instead of a dict,
with no error surfaced anywhere.

**Impact:** an analyst enriching an IOC via the ThreatFox module gets a silent,
malformed return whenever the lookup doesn't succeed cleanly (rate limiting,
transient API errors, or simply no match for the queried value). The
dispatcher can't consume a bare string, so the enrichment appears to fail or
hang with no explanation instead of showing the analyst why it didn't return
results.

**Fix:** the non-200 and non-`"ok"` paths now return `misperrors` with a
descriptive message (HTTP status code, or the ThreatFox `query_status` value).
The success path is otherwise unchanged and still returns the same results
dict.

This is a pure bug fix — no behaviour change to the success path, no
security-relevant default flipped.

### Verification

- `flake8`: clean, no output
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 125.25s (0:02:05)`

Found during a review of the repository; other findings are being submitted
as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

