### PR TITLE
[high] fix: [macvendors] return a dict on the empty-body and error paths

### DIFF
--- a/misp_modules/modules/expansion/macvendors.py
+++ b/misp_modules/modules/expansion/macvendors.py
@@ -47,11 +47,12 @@ def handler(q=False):
         response = r.text
         if response:
             return {"results": [{"types": mispattributes["output"], "values": response}]}
+        return {"results": []}
     elif r.status_code == 404:  # Not found (not an error)
         return {"results": [{"types": mispattributes["output"], "values": "Not found"}]}
     else:  # Real error
         misperrors["error"] = "MacVendors API not accessible (HTTP " + str(r.status_code) + ")"
-        return misperrors["error"]
+        return misperrors
 
 
 def introspection():


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** macvendors `handler()` returns `None` or a bare string instead of a dict on two failure paths.

- **Problem** — When the API answers HTTP 200 with an empty body, `handler()` falls off the end of the `if`/`elif`/`else` and implicitly returns `None`; on a real HTTP error it returns the bare `misperrors["error"]` string rather than the `misperrors` dict. Both break the contract that a handler returns a dict.
- **Fix** — Return an explicit empty results dict for the 200-empty-body case, and the full `misperrors` dict on the error path.
- **Effect** — An analyst enriching a MAC address gets an empty result or a legible error instead of an opaque failure.
<!-- /bluf -->

### The defect

```python
        response = r.text
        if response:
            return {"results": [{"types": mispattributes["output"], "values": response}]}
    elif r.status_code == 404:  # Not found (not an error)
        return {"results": [{"types": mispattributes["output"], "values": "Not found"}]}
    else:  # Real error
        misperrors["error"] = "MacVendors API not accessible (HTTP " + str(r.status_code) + ")"
        return misperrors["error"]
```

Two problems in `macvendors.py`'s `handler()`:

1. When the MacVendors API returns HTTP 200 with an empty body, the `if response:` branch is skipped and the function falls off the end of the `if/elif/else`, implicitly returning `None`.
2. On the "real error" path, the function returns `misperrors["error"]` — a bare string — instead of the `misperrors` dict that the rest of the module's error-handling contract expects.

### Impact

A misp-modules server expects an expansion module's `handler()` to return a dict (either `{"results": [...]}` or the `misperrors` dict). Returning `None` or a bare string breaks that contract: the caller either crashes trying to treat the return value as a mapping, or the enrichment silently fails with no usable error surfaced to the analyst. Either way, an analyst enriching a MAC address gets an opaque failure instead of an empty result or a legible error message.

### Fix

Return `{"results": []}` explicitly when the API responds 200 with an empty body, and return the full `misperrors` dict (instead of just the string value) on the error path — matching the pattern already used by the other branches in this handler.

No behaviour change beyond making the previously-broken paths return well-formed output: both cases already indicated failure/empty-result before, just via values the caller couldn't consume correctly.

### Verification

- `flake8` on the changed file: clean (exit 0)
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 119.29s (0:01:59)`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

