### PR TITLE
[medium] fix: [expansion] return misperrors dict, not misperrors["error"], on API-not-accessible

### DIFF
--- a/misp_modules/modules/expansion/hashdd.py
+++ b/misp_modules/modules/expansion/hashdd.py
@@ -42,7 +42,7 @@ def handler(q=False):
         summary = state["knownlevel"] if state and state["result"] == "SUCCESS" else state["message"]
     else:
         misperrors["error"] = "{} API not accessible".format(hashddapi_url)
-        return misperrors["error"]
+        return misperrors
 
     r = {"results": [{"types": mispattributes["output"], "values": summary}]}
     return r

--- a/misp_modules/modules/expansion/wiki.py
+++ b/misp_modules/modules/expansion/wiki.py
@@ -52,7 +52,7 @@ def handler(q=False):
         summary = result[0]["item"]["value"] if result else "No additional data found on Wikidata"
     except Exception as e:
         misperrors["error"] = "wikidata API not accessible {}".format(e)
-        return misperrors["error"]
+        return misperrors
 
     r = {"results": [{"types": mispattributes["output"], "values": summary}]}
     return r


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `hashdd.py` and `wiki.py` return a bare error string, not the `misperrors` dict, on API failure.

- **Problem** — The "API not accessible" paths in `hashdd.py` and `wiki.py` set `misperrors["error"]` and then return `misperrors["error"]`, handing the dispatcher a bare string where the module API contract expects the `misperrors` dict, as every other error path in these files does.
- **Fix** — Both returns are changed to `misperrors`.
- **Effect** — The failure is no longer swallowed or mishandled by the caller and instead surfaces to the analyst as a normal module error message.
<!-- /bluf -->

Both `hashdd.py` and `wiki.py` return a bare error string instead of the `misperrors` dict on the "API not accessible" path:

```python
misperrors["error"] = "{} API not accessible".format(hashddapi_url)
return misperrors["error"]
```

```python
misperrors["error"] = "wikidata API not accessible {}".format(e)
return misperrors["error"]
```

Every other error path in these same functions (and the module API contract in general, e.g. `geoip_country.py:65`) returns the `misperrors` dict itself, not the string inside it. A module is expected to return either a results dict or `misperrors` (a dict with an `"error"` key) — returning the bare string breaks that contract. When this path is hit, the MISP server-side dispatcher does not receive the expected dict shape, so the error is not surfaced to the analyst the way every other module error is; the failure is effectively swallowed or mishandled by the caller instead of showing up as a normal module error message.

**Fix:** changed both `return misperrors["error"]` to `return misperrors`, aligning the return value with every other error return in the same functions and with the rest of the module API.

**Behaviour change:** the return value on this path changes from a bare string to a dict (`{"error": "..."}`). This is not a new capability or security-relevant change — it corrects the return type to match the contract every other error path in these modules (and the wider module API) already follows, so downstream error handling starts working as intended instead of receiving a malformed response.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification
- `flake8` on both changed files: clean (no output).
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 75.28s (0:01:15)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

