### PR TITLE
[high] fix: [hibp] return explicit result on empty breach list

### DIFF
--- a/misp_modules/modules/expansion/hibp.py
+++ b/misp_modules/modules/expansion/hibp.py
@@ -51,6 +51,7 @@ def handler(q=False):
         breaches = json.loads(r.text)
         if breaches:
             return {"results": [{"types": mispattributes["output"], "values": breaches}]}
+        return {"results": [{"types": mispattributes["output"], "values": "OK (Not Found)"}]}
     elif r.status_code == 404:
         return {"results": [{"types": mispattributes["output"], "values": "OK (Not Found)"}]}
     else:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A successful HIBP lookup with no breaches returns `None` instead of a result.

- **Problem** — `handler()` in the hibp expansion module only returns a result when the breach list is non-empty or the status code is 404, so a successful HTTP 200 response carrying an empty JSON list falls through every branch and the function implicitly returns `None`.
- **Fix** — Adds an explicit return for that case, reusing the same "OK (Not Found)" value already used for the 404 branch.
- **Effect** — An analyst checking an email or account that simply has no breaches now sees a clean result instead of an empty response indistinguishable from a module crash.
<!-- /bluf -->

The `handler()` function in `misp_modules/modules/expansion/hibp.py` mishandles a successful lookup with no breaches:

```python
breaches = json.loads(r.text)
if breaches:
    return {"results": [{"types": mispattributes["output"], "values": breaches}]}
elif r.status_code == 404:
    return {"results": [{"types": mispattributes["output"], "values": "OK (Not Found)"}]}
```

When the HIBP API responds `200 OK` with an empty JSON list body (which the API can return for a "no breaches" result on some endpoints), `breaches` is `[]`, which is falsy. The `if breaches:` branch is skipped, `r.status_code` is `200` (not `404`), so neither branch returns — the function falls through and implicitly returns `None`.

**Impact:** an analyst enriching an email/account attribute with the HIBP module gets a broken/empty module response instead of a clean result, indistinguishable from a module crash, even though the lookup itself succeeded and simply found nothing.

**Fix:** add an explicit `return` for the 200-with-empty-list case, reusing the same "OK (Not Found)" result text already used for the 404 branch, so both "no breaches found" cases report identically to the analyst. One-line addition, no other changes.

### Verification

- `flake8`: clean (no output)
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 55.66s`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

