### PR TITLE
[high] fix: [validin] use default endpoint in hover and construct client inside try

### DIFF
--- a/misp_modules/modules/expansion/validin.py
+++ b/misp_modules/modules/expansion/validin.py
@@ -927,14 +927,14 @@ def hover(q: Any = False) -> Any:
     if not attribute or not attribute.get("value"):
         return {"error": "Missing input."}
 
-    # Ensure endpoint starts with https://
-    client = ValidinDNSClient(
-        config.get("endpoint", ""),
-        config.get("api_key", ""),
-    )
     query_val = attribute["value"]
 
     try:
+        # Ensure endpoint starts with https://
+        client = ValidinDNSClient(
+            config.get("endpoint", "app.validin.com"),
+            config.get("api_key", ""),
+        )
         data = client.get_quick_reputation(attribute["type"], query_val)
 
         # Build a scannable summary string


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Validin hover enrichment fails on default installs because `hover()` defaults the endpoint to `""`.

- **Problem** — `hover()` in the validin expansion module builds `ValidinDNSClient` before its `try` block and defaults the endpoint config key to an empty string, while `handler()` in the same file defaults it to `app.validin.com`; the constructor raises `ValueError` when the endpoint is empty, so every hover enrichment on a default install (where only `api_key` is set) fails with an uncaught exception.
- **Fix** — Aligns `hover()`'s default with `handler()`'s and moves client construction inside the `try` block.
- **Effect** — Hover queries work out of the box, and any construction error returns the module's normal error response.
<!-- /bluf -->

### The defect

`hover()` in `misp_modules/modules/expansion/validin.py` built the `ValidinDNSClient` *before* the `try` block, using an empty default for the endpoint config key:

```python
# Ensure endpoint starts with https://
client = ValidinDNSClient(
    config.get("endpoint", ""),
    config.get("api_key", ""),
)
query_val = attribute["value"]

try:
    data = client.get_quick_reputation(attribute["type"], query_val)
```

`handler()` in the same module defaults the identical config key to `"app.validin.com"`, but `hover()` defaulted it to `""`. `ValidinDNSClient.__init__` raises `ValueError("Validin endpoint is missing.")` when the endpoint is empty, and since the client is constructed outside the `try`, that exception is never caught.

### Impact

On a default MISP install where the `validin` module's `endpoint` config is left unset (which is the normal case — only `api_key` is required), any hover-enrichment request for the `validin` module crashes with an uncaught `ValueError` instead of returning the module's standard `{"error": ...}` response. The analyst sees a hover-query failure rather than a clear, actionable error message.

### The fix

Align `hover()`'s default endpoint with `handler()`'s (`"app.validin.com"`), and move the `ValidinDNSClient` construction inside the `try` block so any construction failure surfaces through the module's normal error-handling path instead of crashing uncaught.

No behaviour change beyond fixing the crash: with no endpoint configured, `hover()` now works exactly like `handler()` already does (querying the public `app.validin.com` endpoint), and any future construction error is now handled the same way `get_quick_reputation` errors already are.

### Verification

- `flake8` on the changed file: clean.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 41.51s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

