### PR TITLE
[medium] fix: [vysion] move proxy settings lookup inside the try block

### DIFF
--- a/misp_modules/modules/expansion/vysion.py
+++ b/misp_modules/modules/expansion/vysion.py
@@ -150,9 +150,9 @@ def handler(q=False):
 
     # event_limit = request["config"].get("event_limit")
     attribute = request["attribute"]
-    proxy_settings = get_proxy_settings(request.get("config"))
 
     try:
+        proxy_settings = get_proxy_settings(request.get("config"))
         vysion, MISPProcessor = _load_vysion_dependencies()
 
         client = vysion.Client(


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An incomplete Vysion proxy configuration crashes the module instead of returning its own error.

- **Problem** — In the vysion expansion module, `handler()` calls `get_proxy_settings()` before entering its `try` block, so the deliberate `KeyError` that helper raises for an incomplete proxy configuration (`proxy_host` without `proxy_port`, or `proxy_username` without `proxy_password`) escapes uncaught instead of being handled by the module's own `except Exception` clause.
- **Fix** — Moves the call to the first line inside the existing `try`.
- **Effect** — A user who misconfigures the Vysion proxy now receives the crafted, actionable message naming the missing setting rather than a stack trace.
<!-- /bluf -->

### The defect

In `misp_modules/modules/expansion/vysion.py`, `handler()` called `get_proxy_settings()` **before** entering its `try` block:

```python
attribute = request["attribute"]
proxy_settings = get_proxy_settings(request.get("config"))

try:
    vysion, MISPProcessor = _load_vysion_dependencies()
    ...
```

`get_proxy_settings()` deliberately sets `misperrors["error"]` and raises a bare `KeyError` when the config has `proxy_host` without `proxy_port`, or `proxy_username` without `proxy_password` — this is meant to be a controlled, user-facing configuration error. But because the call sat outside the `try` block, that `KeyError` propagated straight out of `handler()` uncaught instead of being caught by the module's own `except Exception` handler further down.

### Impact

A MISP analyst who sets an incomplete proxy configuration for the Vysion module (e.g. sets `vysion_proxy_host` but forgets `vysion_proxy_port`) gets an unhandled exception / stack trace out of the module instead of the crafted, actionable error message ("The vysion_proxy_host config is set, please also set the vysion_proxy_port."). This is a crash on a routine misconfiguration, not just a worse error message.

### The fix

Moved the `get_proxy_settings()` call to be the first line inside the existing `try` block, so the `KeyError` it raises on misconfiguration is now caught by the existing `except Exception` clause and returned as the intended `misperrors` message instead of crashing the module. No other behavior changes.

### Verification

- `flake8 misp_modules/modules/expansion/vysion.py` — clean, no output.
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 42.43s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

