### PR TITLE
[high] fix: [ipinfo] guard optional response fields before indexing

### DIFF
--- a/misp_modules/modules/expansion/ipinfo.py
+++ b/misp_modules/modules/expansion/ipinfo.py
@@ -75,16 +75,19 @@ def handler(q=False):
     # Parse the geolocation information related to the IP address
     geolocation = MISPObject("geolocation")
     for field, relation in _GEOLOCATION_OBJECT_MAPPING.items():
-        geolocation.add_attribute(relation, ipinfo[field])
-    for relation, value in zip(("latitude", "longitude"), ipinfo["loc"].split(",")):
-        geolocation.add_attribute(relation, value)
+        if ipinfo.get(field) is not None:
+            geolocation.add_attribute(relation, ipinfo[field])
+    if ipinfo.get("loc") is not None:
+        for relation, value in zip(("latitude", "longitude"), ipinfo["loc"].split(",")):
+            geolocation.add_attribute(relation, value)
     geolocation.add_reference(input_attribute.uuid, "locates")
     misp_event.add_object(geolocation)
 
     # Parse the domain information
     domain_ip = misp_event.add_object(name="domain-ip")
     for feature in ("hostname", "ip"):
-        domain_ip.add_attribute(feature, ipinfo[feature])
+        if ipinfo.get(feature) is not None:
+            domain_ip.add_attribute(feature, ipinfo[feature])
     domain_ip.add_reference(input_attribute.uuid, "resolves")
     if ipinfo.get("domain") is not None:
         for domain in ipinfo["domain"]["domains"]:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `ipinfo` crashes with a `KeyError` on any IP whose response omits an optional field.

- **Problem** — The ipinfo expansion module indexes `ipinfo[field]`, `ipinfo["loc"]` and `ipinfo["hostname"]` directly, so a successful HTTP 200 lookup for an IP with no PTR record or a missing optional geolocation field raises `KeyError` and the whole enrichment crashes.
- **Fix** — Guards each access with an `ipinfo.get(...) is not None` check, matching the style already used for the `asn`, `domain` and `org` fields in the same function.
- **Effect** — Analysts enriching ordinary IP attributes now get a partial result instead of an exception; this covers a large share of real-world addresses.
<!-- /bluf -->

The unguarded dict-index accesses in `modules/expansion/ipinfo.py` crash whenever an ipinfo.io response is missing an optional field:

```python
for field, relation in _GEOLOCATION_OBJECT_MAPPING.items():
    geolocation.add_attribute(relation, ipinfo[field])
for relation, value in zip(("latitude", "longitude"), ipinfo["loc"].split(",")):
    geolocation.add_attribute(relation, value)
...
for feature in ("hostname", "ip"):
    domain_ip.add_attribute(feature, ipinfo[feature])
```

`hostname` in particular is only present in the ipinfo.io response when a PTR record resolves for the IP — so any real, successful (HTTP 200) lookup for an IP without reverse DNS raises a `KeyError` and the module crashes instead of returning a partial result.

### Impact

An analyst enriching an IP attribute with the ipinfo module gets an unhandled exception instead of an enrichment result, for a large fraction of real-world IPs (any without a PTR record, or with other optional geolocation fields absent). This looks like a broken module rather than "no data available."

### Fix

Guard each of these accesses with `ipinfo.get(...) is not None` checks before indexing, mirroring the guard style already used for the `asn`, `domain`, and `org` fields elsewhere in the same function. No behaviour change for responses where the fields are present; a field simply isn't added to the output object when absent, rather than raising.

### Verification

- `flake8` on the changed file: clean.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 53.48s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

