### PR TITLE
[medium] fix: [hyasinsight] avoid AttributeError on transport failures

### DIFF
--- a/misp_modules/modules/expansion/hyasinsight.py
+++ b/misp_modules/modules/expansion/hyasinsight.py
@@ -290,7 +290,7 @@ class RequestHandler:
 
     def get(self, url: str, headers: dict = None, req_body=None) -> requests.Response:
         """General post method to fetch the response from HYAS Insight."""
-        response = []
+        response = None
         try:
             response = self.session.post(url, headers=headers, json=req_body)
             if response:
@@ -299,6 +299,7 @@ class RequestHandler:
             msg = "Error connecting with the HYAS Insight."
             logger.error(f"{msg} Error: {error}")
             misperrors["error"] = msg
+            response = None
         return response
 
     def hyas_lookup(self, end_point: str, query_input, query_param, current=False) -> requests.Response:
@@ -792,7 +793,7 @@ def handler(q=False):
             else:
                 ip_param = IP_PARAM
             enrich_response = request_handler.hyas_lookup(endpoint, ip_param, attribute_value)
-            if endpoint == SSL_CERTIFICATE_ENDPOINT:
+            if endpoint == SSL_CERTIFICATE_ENDPOINT and enrich_response:
                 enrich_response = enrich_response.get("ssl_certs")
             if enrich_response:
                 has_results = True
@@ -808,7 +809,8 @@ def handler(q=False):
                     attribute_value,
                     endpoint == WHOIS_CURRENT_ENDPOINT,
                 )
-                enrich_response = enrich_response.get("items")
+                if enrich_response:
+                    enrich_response = enrich_response.get("items")
             if enrich_response:
                 has_results = True
                 parser.create_misp_attributes_and_objects(enrich_response, endpoint, attribute_value)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `hyasinsight` raises `AttributeError` on transport failures instead of its own error message.

- **Problem** — `RequestHandler.get` in the hyasinsight expansion module initialises its return value to an empty list and leaves it that way when a `ConnectTimeout`, `ProxyError` or `InvalidURL` occurs, but `handler()` then calls `.get("ssl_certs")` or `.get("items")` on that list, raising `AttributeError` instead of returning the error already set.
- **Fix** — Makes the helper return `None` on transport failure and guards both dereference sites with a truthiness check.
- **Effect** — Analysts enriching SSL certificate or WHOIS attributes during a network or proxy problem now see the intended "Error connecting with the HYAS Insight" message rather than an unhandled exception.
<!-- /bluf -->

`RequestHandler.get` in `hyasinsight.py` initialized its return value as an empty list and left it that way on a transport failure:

```python
def get(self, url: str, headers: dict = None, req_body=None) -> requests.Response:
    """General post method to fetch the response from HYAS Insight."""
    response = []
    try:
        response = self.session.post(url, headers=headers, json=req_body)
        if response:
            response = response.json()
    except (ConnectTimeout, ProxyError, InvalidURL) as error:
        msg = "Error connecting with the HYAS Insight."
        logger.error(f"{msg} Error: {error}")
        misperrors["error"] = msg
    return response
```

Two call sites in `handler()` called `.get("ssl_certs")` and `.get("items")` on this value before the generic truthiness guard ran:

```python
if endpoint == SSL_CERTIFICATE_ENDPOINT:
    enrich_response = enrich_response.get("ssl_certs")
...
enrich_response = enrich_response.get("items")
```

`list` has no `.get()` method, so on a `ConnectTimeout`, `ProxyError`, or `InvalidURL` (e.g. a proxy misconfiguration or an unreachable HYAS Insight endpoint) the module crashed with `AttributeError: 'list' object has no attribute 'get'` instead of returning the `misperrors["error"]` message that was already set. An analyst enriching an SSL certificate or WHOIS-current attribute during a transient network issue got an unhandled exception and a confusing MISP error instead of the intended "Error connecting with the HYAS Insight" message.

### Fix

`RequestHandler.get` now returns `None` on these transport failures (instead of leaving the misleading empty-list sentinel), and both unprotected `.get()` call sites are guarded with a truthiness check before dereferencing, so the failure path falls through to the existing `misperrors` surfacing logic instead of raising.

No behaviour change beyond this: successful responses are handled identically; only the previously-crashing failure path is fixed.

### Verification

- `flake8` on the changed file: clean.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 124.33s (0:02:04)`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

