### PR TITLE
[high] fix: [censys_enrich] guard service_name lookup against missing key

### DIFF
--- a/misp_modules/modules/expansion/censys_enrich.py
+++ b/misp_modules/modules/expansion/censys_enrich.py
@@ -163,7 +163,7 @@ def parse_response(censys_output, attribute):
     for serv in censys_output.get("services", []):
         if not isinstance(serv, dict):
             continue
-        if serv.get("service_name").lower() == "http" and serv.get("certificate", None):
+        if (serv.get("service_name") or "").lower() == "http" and serv.get("certificate", None):
             try:
                 cert = serv.get("certificate", None)
                 if cert:
@@ -174,7 +174,7 @@ def parse_response(censys_output, attribute):
                     misp_event.add_object(**cert_obj)
             except KeyError:
                 print("Error !")
-        if serv.get("ssh") and serv.get("service_name").lower() == "ssh":
+        if serv.get("ssh") and (serv.get("service_name") or "").lower() == "ssh":
             try:
                 cert = serv.get("ssh").get("server_host_key").get("fingerprint_sha256")
                 # TODO enable once the type is merged


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A Censys service record without `service_name` crashes the enrichment with `AttributeError`.

- **Problem** — Two call sites in `misp_modules/modules/expansion/censys_enrich.py` call `serv.get("service_name").lower()`, which raises `AttributeError` when a Censys service record omits `service_name`; the nearby `except KeyError` block does not catch it, so the error is unhandled.
- **Fix** — Guards both sites with `(serv.get("service_name") or "").lower()`.
- **Effect** — A Censys expansion lookup whose response contains a service entry without a service name completes and returns its enrichment instead of crashing mid-parse.
<!-- /bluf -->

### The defect

```python
if serv.get("service_name").lower() == "http" and serv.get("certificate", None):
```
```python
if serv.get("ssh") and serv.get("service_name").lower() == "ssh":
```

`dict.get("service_name")` returns `None` when the key is absent from a Censys service record. Calling `.lower()` on that `None` raises `AttributeError`. The nearby `except KeyError:` block does not catch this — `AttributeError` is a different exception type — so the error is unhandled.

### Impact

When a Censys expansion lookup returns a service entry without a `service_name` field, `misp_modules/modules/expansion/censys_enrich.py` crashes mid-parse instead of enriching the event. The analyst gets a module error instead of the (possibly partial) enrichment results for that attribute.

### The fix

Guard both call sites with `(serv.get("service_name") or "").lower()`, so a missing key evaluates to an empty string instead of raising. No other behaviour changes.

### Verification

- `flake8` on the changed file: clean, no output.
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 47.22s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

