### PR TITLE
[high] fix: [assemblyline_query] guard missing fields on classified file objects

### DIFF
--- a/misp_modules/modules/expansion/assemblyline_query.py
+++ b/misp_modules/modules/expansion/assemblyline_query.py
@@ -122,6 +122,8 @@ class AssemblyLineParser:
             tag = {"Tag": [{"name": file_info["classification"].lower()}]}
             filename_attribute.update(tag)
             for feature, attribute in self._file_mapping.items():
+                if feature not in file_info:
+                    continue
                 attribute_payload = attribute.copy()
                 attribute_payload.update(tag)
                 file_object.add_attribute(value=file_info[feature], **attribute_payload)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Classified AssemblyLine results missing an optional field abort enrichment with a `KeyError`.

- **Problem** — The classified branch of `_create_file_object` in `misp_modules/modules/expansion/assemblyline_query.py` indexes all seven `_file_mapping` fields with `file_info[feature]` without checking presence, while the unclassified branch immediately below already skips missing keys.
- **Fix** — Adds the same `if feature not in file_info: continue` guard to the classified branch.
- **Effect** — An AssemblyLine result carrying a classification but missing one of those optional fields yields the partial file object MISP can build rather than failing the enrichment with an uncaught `KeyError`.
<!-- /bluf -->

In `_create_file_object` (`misp_modules/modules/expansion/assemblyline_query.py`), the classified branch built the file object's attributes without checking whether each mapped feature was present in the AssemblyLine result:

```python
if file_info["classification"] != "UNCLASSIFIED":
    tag = {"Tag": [{"name": file_info["classification"].lower()}]}
    filename_attribute.update(tag)
    for feature, attribute in self._file_mapping.items():
        attribute_payload = attribute.copy()
        attribute_payload.update(tag)
        file_object.add_attribute(value=file_info[feature], **attribute_payload)
    return filename_attribute, file_object
```

Every one of the 7 `_file_mapping` fields is indexed unconditionally with `file_info[feature]`, while the unclassified branch immediately below it already guards the same lookup with `if feature not in file_info: continue`.

**Impact:** any AssemblyLine query result that is classified (not `UNCLASSIFIED`) and is missing one of those optional fields raises an uncaught `KeyError`, so the whole enrichment fails and the analyst gets an error instead of the (partial) file object MISP could otherwise have built.

**Fix:** add the same `if feature not in file_info: continue` presence guard to the classified branch, so both branches skip missing fields identically instead of one of them crashing.

This is a bug fix only — it does not change behaviour for any result where all 7 fields are present, and it makes the classified path degrade the same way the unclassified path already does.

### Verification

- `flake8` on the changed file: clean.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 46.94s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

