### PR TITLE
[high] fix: [stairwell] guard malEval labels lookup with key check

### DIFF
--- a/misp_modules/modules/expansion/stairwell.py
+++ b/misp_modules/modules/expansion/stairwell.py
@@ -130,8 +130,8 @@ def parse_response(response: dict):
                 misp_attribute = {"value": response[feature]}
                 misp_attribute.update(attribute)
                 attr = misp_object.add_attribute(**misp_attribute)
-                if feature in ("md5", "sha1", "sha256"):
-                    for label in response["malEval"]["labels"]:
+                if feature in ("md5", "sha1", "sha256") and "malEval" in response:
+                    for label in response["malEval"].get("labels", []):
                         attr.add_tag(label)
     misp_event.add_object(**misp_object)
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `stairwell` hash enrichment crashes when the response carries no malware-evaluation labels.

- **Problem** — The tagging branch in `misp_modules/modules/expansion/stairwell.py` reads `response["malEval"]["labels"]` unconditionally, unlike every other feature in the same function, which is gated by an `if feature in response` check.
- **Fix** — Adds the same `malEval` presence guard and reads labels with `.get("labels", [])`.
- **Effect** — An analyst enriching a hash that Stairwell reports without malware-evaluation labels, such as a clean or unknown sample, still gets the hash, environment and YARA-rule attributes instead of a `KeyError` crash.
<!-- /bluf -->

`stairwell.py`'s tagging branch reads the malEval labels unconditionally, unlike every other feature in the same function which is gated by `if feature in response`:

```python
misp_attribute = {"value": response[feature]}
misp_attribute.update(attribute)
attr = misp_object.add_attribute(**misp_attribute)
if feature in ("md5", "sha1", "sha256"):
    for label in response["malEval"]["labels"]:
        attr.add_tag(label)
```

If a Stairwell API response for a hash lookup omits the `malEval` block, or includes `malEval` without a `labels` key, this raises a `KeyError` and the module crashes instead of returning the enrichment it does have.

**Impact:** A MISP analyst enriching a hash via the Stairwell expansion module gets a hard failure instead of a partial result whenever Stairwell doesn't return malware-evaluation labels for that sample (e.g. clean/unknown files), even though the hash, environment, and YARA-rule attributes were successfully retrieved.

**Fix:** Add the same `"malEval" in response` guard used elsewhere in the function, and use `.get("labels", [])` instead of a direct key access, so a missing block or missing `labels` key degrades to "no tags" instead of raising.

### Verification

- `flake8` on the changed file: clean
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 88.78s (0:01:28)`

No behaviour change for the normal/expected response shape; this only affects previously-crashing edge cases, which now degrade gracefully.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

