### PR TITLE
[medium] fix: [cluster25_expand] validate config presence before use

### DIFF
--- a/misp_modules/modules/expansion/cluster25_expand.py
+++ b/misp_modules/modules/expansion/cluster25_expand.py
@@ -69,16 +69,18 @@ def handler(q=False):
         return False
     request = json.loads(q)
     # validate Cluster25 params
-    if request.get("config"):
-        if request["config"].get("apikey") is None:
-            misperrors["error"] = "Cluster25 apikey is missing"
-            return misperrors
-        if request["config"].get("api_id") is None:
-            misperrors["error"] = "Cluster25 api_id is missing"
-            return misperrors
-        if request["config"].get("base_url") is None:
-            misperrors["error"] = "Cluster25 base_url is missing"
-            return misperrors
+    if not request.get("config"):
+        misperrors["error"] = "Cluster25 config is missing"
+        return misperrors
+    if request["config"].get("apikey") is None:
+        misperrors["error"] = "Cluster25 apikey is missing"
+        return misperrors
+    if request["config"].get("api_id") is None:
+        misperrors["error"] = "Cluster25 api_id is missing"
+        return misperrors
+    if request["config"].get("base_url") is None:
+        misperrors["error"] = "Cluster25 base_url is missing"
+        return misperrors
 
     # validate attribute
     if not request.get("attribute") or not check_input_attribute(request["attribute"]):


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `cluster25_expand` raises a `KeyError` instead of its own error when run with no config.

- **Problem** — In `misp_modules/modules/expansion/cluster25_expand.py` the `apikey`, `api_id` and `base_url` validation sits inside an `if request.get("config")` block, so when config is absent the checks are skipped entirely and later code reaching `request["config"]["api_id"]` raises an unhandled `KeyError`.
- **Fix** — Inverts the guard to return a "Cluster25 config is missing" error first, then runs the three field checks unconditionally, matching `circl_passivedns.py`.
- **Effect** — Running the module before its configuration is filled in produces the module's normal error message in the MISP UI instead of a raw traceback.
<!-- /bluf -->

Cluster25 config validation was nested inside the truthy check it was supposed to guard against:

```python
if request.get("config"):
    if request["config"].get("apikey") is None:
        misperrors["error"] = "Cluster25 apikey is missing"
        return misperrors
    if request["config"].get("api_id") is None:
        misperrors["error"] = "Cluster25 api_id is missing"
        return misperrors
    if request["config"].get("base_url") is None:
        misperrors["error"] = "Cluster25 base_url is missing"
        return misperrors

# validate attribute
if not request.get("attribute") or not check_input_attribute(request["attribute"]):
    ...
```

When `config` is missing or empty, the whole `apikey`/`api_id`/`base_url` block is skipped instead of raising a friendly error, and execution falls through to later code that does `request["config"]["api_id"]`, raising an unhandled `KeyError`.

**Impact on a MISP analyst:** running the Cluster25 expansion module without a configured API key/ID/base URL (e.g. a fresh MISP instance, or a module enabled before its config is filled in) crashes with a raw `KeyError` traceback instead of the module's normal "Cluster25 api_id is missing" style error, making the module's own error reporting misleading and harder to diagnose from the MISP UI.

**Fix:** invert the guard to `if not request.get("config"): return misperrors` (with a new "Cluster25 config is missing" message) first, then run the existing `apikey`/`api_id`/`base_url` checks unconditionally — matching the pattern used elsewhere in the repo (e.g. `circl_passivedns.py`).

No behaviour change beyond replacing an unhandled crash with the module's standard graceful error response; no security defaults or contracts were altered.

### Verification

- `flake8` on the changed file: clean relative to the `9c31e8a1` baseline — identical pre-existing E501 warnings on unchanged lines only, no new warnings on the changed lines (72-82).
- `pytest tests/test_expansions.py`: 161 passed, 4 skipped, 5 subtests passed (one unrelated flaky failure, `test_macvendors`, HTTP 429 rate limit, passed on retry).

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

