### PR TITLE
[high] fix: [urlscan] guard GSB match lookup against missing processor data

### DIFF
--- a/misp_modules/modules/expansion/urlscan.py
+++ b/misp_modules/modules/expansion/urlscan.py
@@ -203,8 +203,9 @@ def lookup_indicator(client, query):
             log.debug("There is something in results > stats > malicious")
             threat_list = set()
 
-            if "matches" in result["meta"]["processors"]["gsb"]["data"]:
-                for item in result["meta"]["processors"]["gsb"]["data"]["matches"]:
+            gsb_data = result.get("meta", {}).get("processors", {}).get("gsb", {}).get("data", {})
+            if "matches" in gsb_data:
+                for item in gsb_data["matches"]:
                     if item["threatType"]:
                         threat_list.add(item["threatType"])
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `urlscan` enrichments crash with a `KeyError` when a non-GSB engine flags a submission malicious.

- **Problem** — The `stats.malicious` branch of `lookup_indicator` in `misp_modules/modules/expansion/urlscan.py` indexes straight into `result["meta"]["processors"]["gsb"]["data"]`, assuming Google Safe Browsing data is present whenever urlscan flags a submission malicious, which is untrue when another engine produced the verdict.
- **Fix** — Resolves that value through a `.get()` chain and iterates only when it exists.
- **Effect** — urlscan enrichments flagged malicious by a non-GSB engine return their results instead of aborting the module with an uncaught `KeyError`.
<!-- /bluf -->

The `stats.malicious` branch of `lookup_indicator` in `misp_modules/modules/expansion/urlscan.py` directly indexed into the Google Safe Browsing processor data:

```python
if "matches" in result["meta"]["processors"]["gsb"]["data"]:
    for item in result["meta"]["processors"]["gsb"]["data"]["matches"]:
        if item["threatType"]:
            threat_list.add(item["threatType"])
```

This assumes GSB data is always present whenever urlscan reports `stats.malicious` as truthy. In practice, urlscan.io aggregates verdicts from several engines (GSB, urlscan's own classifier, community/Microsoft/other integrations), so `malicious` can be set with the `gsb` processor entry absent or missing its `data`/`matches` keys.

**Impact on an analyst**: any urlscan.io enrichment where a submission is flagged malicious by a non-GSB engine raises an uncaught `KeyError`, aborting the whole module response — the analyst gets no enrichment at all (not even the parts of the result that were successfully retrieved) instead of a degraded-but-useful result.

**Fix**: build a `gsb_data` value via a `.get()` chain (`result.get("meta", {}).get("processors", {}).get("gsb", {}).get("data", {})`), matching the defensive `.get()` style already used elsewhere in this function, and check/iterate on that instead of direct indexing. When GSB data is absent, the loop is simply skipped and the rest of the result is returned normally.

No behaviour change for the case GSB data is present; this only prevents a crash in the previously-unhandled case.

### Verification

- `flake8 misp_modules/modules/expansion/urlscan.py` — clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 31.56s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

