### PR TITLE
[medium] fix: [alphaMountain] fix falsy-response check in HTTP error handler

### DIFF
--- a/misp_modules/modules/expansion/alphaMountain.py
+++ b/misp_modules/modules/expansion/alphaMountain.py
@@ -130,8 +130,8 @@ def query_alphamountain_api(api_url, license_key, ioc_value, scan_depth, partner
         return response.json()
 
     except requests.exceptions.HTTPError as e:
-        status = response.status_code if response else "No status"
-        body = response.text[:500] if response else "No response body"
+        status = response.status_code if response is not None else "No status"
+        body = response.text[:500] if response is not None else "No response body"
         raise ValueError(f"HTTP {status}: {body} - {str(e)}")
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** alphaMountain's HTTP error handler tests a `Response` for truthiness, so it always discards the real error.

- **Problem** — In `misp_modules/modules/expansion/alphaMountain.py` the handler tests a `requests.Response` for truthiness, but `Response.__bool__` returns `self.ok`, which is false for exactly the 4xx and 5xx statuses that reach this branch, so the real status code and body are always discarded in favour of the `"No status"` / `"No response body"` fallback.
- **Fix** — Changes both checks to explicit `is not None` tests.
- **Effect** — An alphaMountain failure such as a bad API key or rate limit surfaces the vendor's actual status code and message to the analyst instead of an unusable placeholder error.
<!-- /bluf -->

The except-branch for HTTP errors used truthiness on a `requests.Response` object to decide whether a response was available:

```python
except requests.exceptions.HTTPError as e:
    status = response.status_code if response else "No status"
    body = response.text[:500] if response else "No response body"
    raise ValueError(f"HTTP {status}: {body} - {str(e)}")
```

`requests.Response.__bool__` is defined as `self.ok`, which is `False` for any 4xx/5xx status. Those are exactly the statuses that trigger `raise_for_status()` and land execution in this except block. So `if response` is `False` on every single invocation of this branch, and the code always fell into the `"No status"` / `"No response body"` fallback — the real HTTP status code and response body from alphaMountain were discarded every time.

**Impact:** When the alphaMountain API returns an error (bad API key, rate limiting, invalid IOC, server error, etc.), the MISP analyst sees a useless `HTTP No status: No response body - ...` error instead of the actual status code and error message from the vendor, making it impossible to diagnose the failure without external debugging.

**Fix:** Changed both truthiness checks to explicit `is not None` checks, so the real `status_code` and `text` are surfaced whenever a `Response` object exists.

No behaviour change beyond this: error messages now contain accurate diagnostic information instead of always showing the fallback text.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `flake8` on the changed file: clean (exit 0)
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 30.88s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

