### PR TITLE
[critical] fix: [cytomic_orion] use .get() for API fields and stop disabling TLS verification

### DIFF
--- a/misp_modules/modules/expansion/cytomic_orion.py
+++ b/misp_modules/modules/expansion/cytomic_orion.py
@@ -51,6 +51,7 @@ moduleconfig = [
     "upload_threat_level_id",
     "limit_upload_events",
     "limit_upload_attributes",
+    "verify_ssl",
 ]
 # There are more config settings in this module than used by the enrichment
 # There is also a PyMISP module which reuses the module config, and requires additional configuration, for example used for pushing indicators to the API
@@ -64,6 +65,7 @@ class CytomicParser:
         self.misp_event.add_attribute(**self.attribute)
 
         self.config_object = config_object
+        self.verify_ssl = config_object.get("verify_ssl", True) if config_object else True
 
         if self.config_object:
             self.token = self.get_token()
@@ -92,7 +94,7 @@ class CytomicParser:
                     access_token_response = requests.post(
                         token_url,
                         data=data,
-                        verify=False,
+                        verify=self.verify_ssl,
                         allow_redirects=False,
                         auth=(clientid, clientsecret),
                     )
@@ -136,7 +138,7 @@ class CytomicParser:
             # API calls
             api_call_headers = {"Authorization": "Bearer " + self.token}
             result_query_endpoint_fileinformation = requests.get(
-                query_endpoint_fileinformation, headers=api_call_headers, verify=False
+                query_endpoint_fileinformation, headers=api_call_headers, verify=self.verify_ssl
             )
             json_result_query_endpoint_fileinformation = json.loads(result_query_endpoint_fileinformation.text)
 
@@ -147,37 +149,37 @@ class CytomicParser:
                 cytomic_object.add_attribute(
                     "fileName",
                     type="text",
-                    value=json_result_query_endpoint_fileinformation["fileName"],
+                    value=json_result_query_endpoint_fileinformation.get("fileName"),
                 )
                 cytomic_object.add_attribute(
                     "fileSize",
                     type="text",
-                    value=json_result_query_endpoint_fileinformation["fileSize"],
+                    value=json_result_query_endpoint_fileinformation.get("fileSize"),
                 )
                 cytomic_object.add_attribute(
                     "last-seen",
                     type="datetime",
-                    value=json_result_query_endpoint_fileinformation["lastSeen"],
+                    value=json_result_query_endpoint_fileinformation.get("lastSeen"),
                 )
                 cytomic_object.add_attribute(
                     "first-seen",
                     type="datetime",
-                    value=json_result_query_endpoint_fileinformation["firstSeen"],
+                    value=json_result_query_endpoint_fileinformation.get("firstSeen"),
                 )
                 cytomic_object.add_attribute(
                     "classification",
                     type="text",
-                    value=json_result_query_endpoint_fileinformation["classification"],
+                    value=json_result_query_endpoint_fileinformation.get("classification"),
                 )
                 cytomic_object.add_attribute(
                     "classificationName",
                     type="text",
-                    value=json_result_query_endpoint_fileinformation["classificationName"],
+                    value=json_result_query_endpoint_fileinformation.get("classificationName"),
                 )
                 self.misp_event.add_object(**cytomic_object)
 
                 result_query_endpoint_machines = requests.get(
-                    query_endpoint_machines, headers=api_call_headers, verify=False
+                    query_endpoint_machines, headers=api_call_headers, verify=self.verify_ssl
                 )
                 json_result_query_endpoint_machines = json.loads(result_query_endpoint_machines.text)
 
@@ -193,7 +195,7 @@ class CytomicParser:
                             result_endpoint_machines_client = requests.get(
                                 query_endpoint_machines_client,
                                 headers=api_call_headers,
-                                verify=False,
+                                verify=self.verify_ssl,
                             )
                             json_result_endpoint_machines_client = json.loads(result_endpoint_machines_client.text)
 
@@ -292,6 +294,7 @@ def handler(q=False):
         ),
         "query_machines": True,
         "query_machine_info": True,
+        "verify_ssl": str(request["config"].get("verify_ssl") or "true").lower() not in ("false", "0", "no"),
     }
 
     cytomic_parser = CytomicParser(attribute, config_object)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `cytomic_orion` disables TLS verification on all four requests and crashes on partial API responses.

- **Problem** — All four outbound `requests` calls in `misp_modules/modules/expansion/cytomic_orion.py` hardcode `verify=False`, including the OAuth token exchange, so any TLS certificate from the configured `api_url` is accepted; the file-information handler also indexes six response fields directly, raising `KeyError` on a partial response.
- **Fix** — Adds a `verify_ssl` config option defaulting to true and converts those six lookups to `.get()`.
- **Effect** — Cytomic Orion credentials and tokens are protected by certificate validation by default, and an MD5 enrichment returns the fields the API did send instead of failing.
- **Cost** — Deployments whose Orion endpoint uses a self-signed or otherwise unverifiable certificate must explicitly set `verify_ssl` to false.
<!-- /bluf -->

The file-information handler in `cytomic_orion.py` indexed six response fields directly off the parsed JSON after only checking that the parent dict was truthy:

```python
if json_result_query_endpoint_fileinformation:
    cytomic_object.add_attribute(
        "fileName",
        type="text",
        value=json_result_query_endpoint_fileinformation["fileName"],
    )
    ...
```

If the Cytomic Orion API returns a file-information object that is missing any one of `fileName`, `fileSize`, `lastSeen`, `firstSeen`, `classification`, or `classificationName`, this raises an uncaught `KeyError` and the whole enrichment crashes instead of returning a partial result.

Separately, all four outbound `requests.post`/`requests.get` calls hardcoded `verify=False`:

```python
access_token_response = requests.post(
    token_url,
    data=data,
    verify=False,
    allow_redirects=False,
    auth=(clientid, clientsecret),
)
```

which means the module unconditionally accepted any TLS certificate presented by the configured Orion endpoint — including during the OAuth token exchange — regardless of validity, silently defeating certificate validation.

**Impact on a MISP user/analyst:** an analyst enriching an MD5 hash can have the enrichment fail outright on a well-formed-but-partial API response, instead of getting the fields that were actually returned. And because certificate validation was always off, credentials and the bearer token are exposed to interception/tampering by anyone able to man-in-the-middle the configured `api_url`, with no way to opt back into verification.

### Fix

Changed the six direct-index lookups to `.get()` so a missing key returns `None` instead of raising. Added a `verify_ssl` module config option (defaulting to `true`, matching the convention already used by `vmware_nsx.py` and `reversinglabs_spectra_analyze.py`) and threaded it through all four `requests` calls in place of the hardcoded `verify=False`.

### Behaviour change

TLS verification now defaults to **on**. This is an intentional security-default flip, not incidental: any existing deployment pointed at an Orion endpoint with a self-signed or otherwise unverifiable certificate will start failing requests until the operator adds `verify_ssl: false` to the module config. That is the intended outcome of closing this finding — it turns a silent, unconditional bypass into an explicit, auditable opt-out.

### Verification

- `flake8 misp_modules/modules/expansion/cytomic_orion.py` — clean, no output.
- `python -m py_compile misp_modules/modules/expansion/cytomic_orion.py` — succeeded, no output.
- Full pytest suite run by the author of this fix against a local misp-modules server: `161 passed, 4 skipped, 5 subtests passed in 36.83s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

