### PR TITLE
[high] fix: [mispjson] report parse errors instead of silently returning empty results

### DIFF
--- a/misp_modules/modules/import_mod/mispjson.py
+++ b/misp_modules/modules/import_mod/mispjson.py
@@ -45,8 +45,9 @@ def handler(q=False):
             if a.get("data"):
                 tmp["data"] = a["data"]
             r["results"].append(tmp)
-    except Exception:
-        pass
+    except Exception as e:
+        misperrors["error"] = "An error occured during parsing of input: '%s'" % (str(e),)
+        return misperrors
     return r
 
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `mispjson` swallows all parse errors, so a corrupt import silently looks like an empty event.

- **Problem** — The `handler()` function in `misp_modules/modules/import_mod/mispjson.py` wraps its whole parsing path in a bare `except Exception: pass`, so malformed input, invalid base64 or a missing key silently yields an empty results list.
- **Fix** — Captures the exception, sets `misperrors["error"]` with its message and returns it, matching the pattern already used in `cof2misp.py`.
- **Effect** — An analyst importing a truncated or corrupted MISP JSON export sees the real failure instead of an import screen showing zero results as though the file were simply empty.
<!-- /bluf -->

The `handler()` function in `mispjson.py` wraps its entire parsing logic in a bare, silent exception handler:

```python
    except Exception:
        pass
    return r
```

Any malformed input, invalid base64, or missing expected key causes the module to silently return `{"results": []}` instead of an error. This is indistinguishable from a legitimately empty/no-hit event.

**Impact:** An analyst importing a JSON MISP event export that fails to parse (truncated file, wrong format, corrupted base64 attachment, etc.) gets no indication anything went wrong — the import UI shows zero results as if the file was simply empty, and the real failure is silently swallowed.

**Fix:** The `except` block now captures the exception, sets `misperrors["error"]` with the exception message, and returns `misperrors`, matching the existing error-reporting pattern already used elsewhere in the codebase (e.g. `cof2misp.py`).

No behaviour change beyond surfacing the previously-swallowed error to the caller; success-path behaviour (a well-formed event) is unaffected.

### Verification

- `flake8 misp_modules/modules/import_mod/mispjson.py` — clean, no output.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 19.41s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

