### PR TITLE
[critical] fix: [assemblyline_query] remove world-readable debug dump of parsed events

### DIFF
--- a/misp_modules/modules/expansion/assemblyline_query.py
+++ b/misp_modules/modules/expansion/assemblyline_query.py
@@ -91,11 +91,6 @@ class AssemblyLineParser:
         if "error" in self.results:
             return self.results
         event = json.loads(self.misp_event.to_json())
-        try:
-            with open("/tmp/assemblyline_query_debug.json", "w", encoding="utf-8") as debug_file:
-                json.dump(event, debug_file, indent=2)
-        except Exception:
-            pass
         results = {key: event[key] for key in ("Attribute", "Object", "Tag") if (key in event and event[key])}
         if not results:
             return {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `assemblyline_query` dumps every parsed event to a world-readable `/tmp` file on every query.

- **Problem** — The `finalize_results` method of `AssemblyLineParser` in `misp_modules/modules/expansion/assemblyline_query.py` writes the full parsed MISP event to a fixed `/tmp/assemblyline_query_debug.json` path on every successful query, with no config flag, no cleanup and default umask permissions.
- **Fix** — Deletes those five lines outright; nothing downstream reads the file.
- **Effect** — AssemblyLine classification data and the indicators that prompted each query are no longer exposed to other local users or containers sharing `/tmp`, and the module's returned attributes, objects and tags are unchanged.
<!-- /bluf -->

The `finalize_results` method in `AssemblyLineParser` unconditionally wrote the full parsed MISP event to a fixed, world-readable path on every successful query:

```python
event = json.loads(self.misp_event.to_json())
try:
    with open("/tmp/assemblyline_query_debug.json", "w", encoding="utf-8") as debug_file:
        json.dump(event, debug_file, indent=2)
except Exception:
    pass
```

This dump had no config flag to disable it, no cleanup afterward, and no restrictive file permissions — `/tmp` is world-readable on typical multi-user systems, and the file itself inherited the default umask (commonly `0644`). The dumped content included the parsed MISP event's Attributes, Objects, and Tags, i.e. the AssemblyLine classification data being pulled into the event, plus whatever indicator data prompted the query.

**Impact:** any other local user or process on the MISP server (or any worker/container sharing `/tmp`) could read the AssemblyLine classification results and indicator data from recent enrichment queries, and each query silently overwrote the previous dump, leaking data with no opt-in, no audit trail, and no way for an analyst to disable it short of patching the module.

**Fix:** removed the debug dump entirely — nothing downstream reads this file, so deleting it is the minimal fix (the alternative, gating it behind an explicit debug flag writing to a `0600` file, was not needed since the dump was pure dead debug code with no consumer).

This is a pure deletion with no behavior change to the module's actual output (`Attribute`/`Object`/`Tag` results returned to MISP are unaffected).

### Verification

- `flake8 misp_modules/modules/expansion/assemblyline_query.py` — clean, no output.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 31.27s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

