### PR TITLE
[critical] fix: [wiki] escape SPARQL literal built from user text

### DIFF
--- a/misp_modules/modules/expansion/wiki.py
+++ b/misp_modules/modules/expansion/wiki.py
@@ -43,7 +43,8 @@ def handler(q=False):
             " Chrome/50.0.2661.102 Safari/537.36"
         ),
     )
-    query_string = 'SELECT ?item \nWHERE { \n?item rdfs:label"' + request.get("text") + '" @en \n}\n'
+    escaped_text = request.get("text").replace("\\", "\\\\").replace('"', '\\"')
+    query_string = 'SELECT ?item \nWHERE { \n?item rdfs:label"' + escaped_text + '" @en \n}\n'
     sparql.setQuery(query_string)
     sparql.setReturnFormat(JSON)
     results = sparql.query().convert()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `wiki.py` interpolates untrusted text into a SPARQL literal unescaped, allowing query injection.

- **Problem** — `misp_modules/modules/expansion/wiki.py` builds its SPARQL query by concatenating the untrusted `text` attribute into a quoted literal, and `SPARQLWrapper` does not escape it, so a value containing a double quote or backslash injects arbitrary SPARQL into the query sent to Wikidata.
- **Fix** — Escapes backslashes and double quotes before interpolation.
- **Effect** — Analysts enriching attributes from shared events or feeds can no longer have the query manipulated into falsified enrichment results.
<!-- /bluf -->

### The defect

`misp_modules/modules/expansion/wiki.py` built its SPARQL query by string-concatenating the untrusted `text` attribute directly into a quoted literal:

```python
query_string = 'SELECT ?item \nWHERE { \n?item rdfs:label"' + request.get("text") + '" @en \n}\n'
```

`SPARQLWrapper` does not escape values interpolated into a manually built query string. Any `text` value containing a double quote (or backslash) breaks out of the string literal, letting an attacker-controlled attribute inject arbitrary SPARQL into the query sent to Wikidata's public endpoint.

### Impact

The `wiki` expansion module is typically run against attribute values pulled from event data, which may originate from external/untrusted sources (e.g. shared events, automated feeds). A crafted `text` value can manipulate the SPARQL query executed on behalf of the analyst, altering or corrupting the enrichment results returned into the MISP event. The endpoint is read-only and public, so this is query manipulation / false enrichment output, not data exfiltration or compromise of the endpoint itself.

### The fix

Escape backslashes and double quotes in `text` before interpolating it into the query string literal, following standard SPARQL literal escaping rules. Text with no special characters produces an identical query to before, so there is no behaviour change for the common case.

### Verification

- `.venv/bin/python -m py_compile misp_modules/modules/expansion/wiki.py` — compiles cleanly.
- Fixer's full run: flake8 clean (rc=0); test suite 161 passed, 4 skipped, 5 subtests passed in 37.61s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

