### PR TITLE
[medium] fix: [__main__] don't mask AttributeErrors raised inside dict_handler

### DIFF
--- a/misp_modules/__main__.py
+++ b/misp_modules/__main__.py
@@ -226,9 +226,9 @@ class QueryModule(tornado.web.RequestHandler):
     @tornado_concurrent.run_on_executor
     def run_request(self, module_name, json_payload, dict_payload):
         LOGGER.debug("QueryModule %s request %s", module_name, json_payload)
-        try:
+        if hasattr(MODULES_HANDLERS[module_name], "dict_handler"):
             response = MODULES_HANDLERS[module_name].dict_handler(request=dict_payload)
-        except AttributeError:
+        else:
             response = MODULES_HANDLERS[module_name].handler(q=json_payload)
         return orjson.dumps(response, default=pymisp.pymisp_json_default)
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A bare `except AttributeError` in `run_request` masks real bugs inside a module's `dict_handler`.

- **Problem** — `QueryModule.run_request` in `misp_modules/__main__.py` wraps the `dict_handler()` call in a bare `except AttributeError` to detect modules that lack one, which also swallows any `AttributeError` raised inside a working `dict_handler` and silently re-dispatches to the legacy `handler(q=...)` path.
- **Fix** — Replaces the guard with an explicit `hasattr()` check so only genuinely missing implementations fall back.
- **Effect** — Real bugs inside a module's `dict_handler` now surface as errors rather than returning quietly different results through the fallback path.
<!-- /bluf -->

`QueryModule.run_request` in `misp_modules/__main__.py` used a bare `except AttributeError` to detect modules that lack a `dict_handler` implementation:

```python
try:
    response = MODULES_HANDLERS[module_name].dict_handler(request=dict_payload)
except AttributeError:
    response = MODULES_HANDLERS[module_name].handler(q=json_payload)
```

The problem is that this `except` catches *any* `AttributeError`, including one raised from inside a working `dict_handler` implementation (e.g. a `None.something` access on malformed input, or a missing attribute on an internal object). Such an error gets silently swallowed and the request is silently re-dispatched to the legacy `handler(q=...)` path instead of failing loudly.

**Impact on a MISP user/analyst:** a genuine bug in a module's `dict_handler` is masked. The request appears to succeed via the fallback path (possibly with different/incomplete behavior or stale results) instead of surfacing an error, making the underlying defect much harder to detect and diagnose.

**Fix:** replace the broad `except AttributeError` with an explicit `hasattr(MODULES_HANDLERS[module_name], "dict_handler")` check before calling it. Only modules that genuinely lack `dict_handler` now fall back to `handler(q=...)`; any `AttributeError` raised from inside a real `dict_handler` implementation now propagates instead of being masked.

This does not change behavior for any currently-working module (every module either has `dict_handler` or doesn't); it only stops masking errors raised inside `dict_handler` implementations that do exist.

### Verification

- `flake8` on the changed file: clean (no output)
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 26.38s`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

