### PR TITLE
[critical] fix: [import_mod/lib] use defusedxml for GoAML and ODT parsing

### DIFF
--- a/misp_modules/lib/ODTReader/odtreader.py
+++ b/misp_modules/lib/ODTReader/odtreader.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import argparse
 import sys
-import xml.etree.ElementTree as ET
 from zipfile import ZipFile
+
+import defusedxml.ElementTree as ET
 
 if sys.platform == "win32":
     import win32_unicode_argv

--- a/misp_modules/modules/import_mod/goamlimport.py
+++ b/misp_modules/modules/import_mod/goamlimport.py
@@ -1,8 +1,8 @@
 import base64
 import json
 import time
-import xml.etree.ElementTree as ET
 
+import defusedxml.ElementTree as ET
 from pymisp import MISPEvent, MISPObject
 
 misperrors = {"error": "Error"}


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** GoAML and ODT import parsing uses unhardened ElementTree, so a crafted file can DoS the module worker.

- **Problem** — `goamlimport.py` and `lib/ODTReader/odtreader.py` both parse user-supplied import data with `xml.etree.ElementTree.fromstring`, which expands nested internal entities and resolves external ones, so a crafted GoAML report or `.odt` `content.xml` can exhaust memory and CPU.
- **Fix** — Swaps both imports to `defusedxml.ElementTree`, a drop-in replacement here since only `fromstring` is used.
- **Effect** — Submitting a malicious import file can no longer deny service to the module server.
- **Cost** — `defusedxml` is currently a transitive dependency in `poetry.lock`, not one declared in `pyproject.toml`.
<!-- /bluf -->

### The defect

Both `goamlimport.py` and `odtreader.py` parse attacker-supplied XML with the standard library's `xml.etree.ElementTree`, which is not hardened against XML entity-expansion attacks:

```python
# misp_modules/modules/import_mod/goamlimport.py:251
self.tree = ET.fromstring(data)

# misp_modules/lib/ODTReader/odtreader.py:31
root = ET.fromstring(odtContent)
```

`xml.etree.ElementTree.fromstring` will happily expand nested internal entities (e.g. "billion laughs") or resolve external entities, so a crafted GoAML report or a crafted `content.xml` inside an `.odt` file can exhaust memory/CPU on the misp-modules worker.

### Impact

A MISP user importing a malicious GoAML report or a malicious `.odt` file (both are user-supplied import inputs) can cause a denial-of-service against the misp-modules server process handling the import — no authentication beyond "can submit an import" is required.

### Fix

Swap the import to `defusedxml.ElementTree`, which rejects entity expansion and external entity resolution while preserving the same `fromstring` API used at both call sites (`ET.fromstring` only — no other `ET.*` attributes are used in either file, so this is a drop-in replacement here). No behaviour change for well-formed, non-malicious input.

`defusedxml` (0.7.1) is already present in `poetry.lock` as a transitive dependency of `sigmf`, so no new dependency is introduced by this change — only the import is swapped. It is not currently declared as a direct dependency in `pyproject.toml`; maintainers may want to promote it to a direct dependency now that the code relies on it explicitly rather than transitively.

### Verification

- `flake8` clean on `goamlimport.py`; `py_compile` clean on `odtreader.py`.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 24.63s`.
- Confirmed both files use only `ET.fromstring` (`grep -n 'ET\.' ...`), which `defusedxml.ElementTree` supports directly.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

