### PR TITLE
[critical] fix: [sourcecache] validate URLs before archiving to block SSRF

### DIFF
--- a/misp_modules/modules/expansion/sourcecache.py
+++ b/misp_modules/modules/expansion/sourcecache.py
@@ -1,4 +1,7 @@
+import ipaddress
 import json
+import socket
+from urllib.parse import urlparse
 
 from url_archiver import url_archiver
 
@@ -25,6 +28,21 @@ moduleinfo = {
 moduleconfig = ["archivepath"]
 
 
+def is_safe_url(url):
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        resolved = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror:
+        return False
+    for info in resolved:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            return False
+    return True
+
+
 def handler(q=False):
     if q is False:
         return False
@@ -35,15 +53,18 @@ def handler(q=False):
         archive_path = "/tmp/"
     if request.get("link"):
         tocache = request["link"]
-        data = __archiveLink(archive_path, tocache)
-        mispattributes["output"] = ["attachment"]
+        output = ["attachment"]
     elif request.get("url"):
         tocache = request["url"]
-        data = __archiveLink(archive_path, tocache)
-        mispattributes["output"] = ["malware-sample"]
+        output = ["malware-sample"]
     else:
         misperrors["error"] = "Link is missing"
         return misperrors
+    if not is_safe_url(tocache):
+        misperrors["error"] = "Blocked URL"
+        return misperrors
+    data = __archiveLink(archive_path, tocache)
+    mispattributes["output"] = output
     enc_data = data.decode("ascii")
     r = {"results": [{"types": mispattributes["output"], "values": tocache, "data": enc_data}]}
     return r


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `sourcecache` archives any URL from an attacker-controlled attribute, making enrichment an SSRF primitive.

- **Problem** — `misp_modules/modules/expansion/sourcecache.py` passes the attacker-controlled `link`/`url` attribute straight into `__archiveLink()` and `url_archiver`'s `fetch()` with no validation.
- **Fix** — Adds an `is_safe_url()` check requiring an `http`/`https` scheme and a globally routable resolved address, mirroring `qrcode.py`, and returns a `"Blocked URL"` misperror otherwise.
- **Effect** — Enriching a hostile attribute can no longer make the MISP server request internal-only targets such as loopback services or cloud metadata endpoints and store the response back as an attachment.
<!-- /bluf -->

The `sourcecache` expansion module passes the attacker-controlled `link`/`url` attribute straight to the archiver with no validation:

```python
if request.get("link"):
    tocache = request["link"]
    data = __archiveLink(archive_path, tocache)
    mispattributes["output"] = ["attachment"]
elif request.get("url"):
    tocache = request["url"]
    data = __archiveLink(archive_path, tocache)
    mispattributes["output"] = ["malware-sample"]
```

`__archiveLink` hands this value directly to `url_archiver.Archive.fetch()`. Since MISP users routinely enrich attacker-supplied `link`/`url` attributes, this lets a malicious event trigger a server-side request to any URL the MISP instance can reach — e.g. `http://127.0.0.1:6379/`, cloud metadata endpoints, or other internal-only services — and the fetched response is stored back into MISP as a cached attachment, effectively an SSRF-to-data-exfiltration primitive reachable by enriching a hostile attribute.

### Impact
An analyst who runs the `sourcecache` module on an attribute from an untrusted event can unknowingly cause the MISP server to reach internal-only services and have the response persisted into the event as an "attachment" or "malware-sample" attribute, disclosing internal service data through the MISP UI.

### Fix
Added an `is_safe_url()` check — scheme must be `http`/`https` and the hostname must resolve only to globally-routable IPs (via `ipaddress.is_global`) — mirroring the hardened validation already used in `qrcode.py`. The module now returns a `"Blocked URL"` misperror instead of fetching when the check fails; no other behaviour changes.

### Verification
- `flake8` (run from the worktree root so `pyproject.toml`'s `[tool.flake8] extend-ignore` applies): clean, no warnings on the changed file.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 24.90s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

