### PR TITLE
[high] fix: [csvimport] avoid AttributeError on unset header/delimiter config

### DIFF
--- a/misp_modules/modules/import_mod/csvimport.py
+++ b/misp_modules/modules/import_mod/csvimport.py
@@ -366,8 +366,12 @@ def dict_handler(request: dict):
         return misperrors
     has_header = request["config"].get("has_header")
     has_header = True if has_header == "1" else False
-    header = request["config"]["header"].split(",") if request["config"].get("header").strip() else []
-    delimiter = request["config"]["special_delimiter"] if request["config"].get("special_delimiter").strip() else ","
+    header = request["config"]["header"].split(",") if (request["config"].get("header") or "").strip() else []
+    delimiter = (
+        request["config"]["special_delimiter"]
+        if (request["config"].get("special_delimiter") or "").strip()
+        else ","
+    )
     data = __standard_parsing(data) if delimiter == "," else __special_parsing(data, delimiter)
     if not header:
         if has_header:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `csvimport` raised `AttributeError` when `header` or `special_delimiter` were unset.

- **Problem** — `dict_handler()` in `misp_modules/modules/import_mod/csvimport.py` calls `.strip()` directly on `request['config'].get('header')` and `.get('special_delimiter')`, which return `None` when those optional keys are absent, so the call raises before the intended defaults are reached.
- **Fix** — Wrap both lookups as `(value or '').strip()`, so a missing key is treated as an empty string and the existing fallback logic runs.
- **Effect** — A CSV import run without an explicit header or delimiter setting falls back to the documented defaults instead of failing outright with an unhandled exception. No change when the keys are set.
<!-- /bluf -->

`csvimport`'s `dict_handler()` crashes when the module is invoked without the optional `header` / `special_delimiter` config keys set:

```python
header = request["config"]["header"].split(",") if request["config"].get("header").strip() else []
delimiter = request["config"]["special_delimiter"] if request["config"].get("special_delimiter").strip() else ","
```

`request["config"].get("header")` (and the delimiter equivalent) returns `None` when the key is absent, and `None.strip()` raises `AttributeError` before the intended fallback (empty header list / `,` delimiter) is ever reached.

**Impact:** an analyst importing a CSV via this module without explicitly setting `header` or `special_delimiter` in the config gets an unhandled `AttributeError` instead of the module falling back to its documented defaults — the import fails outright rather than degrading gracefully.

**Fix:** wrap both `.get(...)` calls as `(request["config"].get(key) or "").strip()`, so a missing key is treated as an empty string and the existing fallback logic (empty header list / `,` delimiter) runs as originally intended. No change to behavior when the keys are present and set.

### Verification

- `flake8 misp_modules/modules/import_mod/csvimport.py` — clean, no output.
- Started the misp-modules server (`python -m misp_modules -l 127.0.0.1 -p 6666`) and ran the full test suite: `python -m pytest tests/ -q` → `161 passed, 4 skipped, 5 subtests passed in 20.10s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

