### PR TITLE
[high] fix: [website/history] use identity check for session node index

### DIFF
--- a/website/app/history/history_core.py
+++ b/website/app/history/history_core.py
@@ -164,7 +164,7 @@ def remove_node_session(node_uuid):
                 if util_remove_node_session(node_uuid, q_value, sess[keys_list[i]]):
                     loc = i
                     break
-    if loc:
+    if loc is not None:
         del sess[keys_list[i]]
 
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** History node removal used `if loc:`, so deleting the first entry silently did nothing.

- **Problem** — The remove-node path in `website/app/history/history_core.py` guards the delete with `if loc:`, but `loc` is a list index and index `0` is falsy, so a match at the first position is skipped even though it was found.
- **Fix** — Change the guard to `if loc is not None:`, keeping the `None` sentinel as the only no-match case.
- **Effect** — Deleting the first entry in the history tree now actually removes it, instead of the UI reporting success while the session dict keeps the stale node. No behaviour change for any non-zero match.
<!-- /bluf -->

The session history "remove node" flow silently no-ops when the matched node is the very first entry in the session's ordered key list:

```python
    if loc:
        del sess[keys_list[i]]
```

`loc` holds the *index* of the matched node, and index `0` is falsy in Python, so `if loc:` skips the delete precisely when the match is at position 0 — even though `loc` was correctly set (as opposed to its `None` initial value meaning "no match").

**Impact on an analyst:** deleting the first node/session shown in the MISP-modules history tree appears to succeed (the UI reports "Node deleted") but the entry is never actually removed from the underlying session dict, leaving stale/duplicate history state.

**Fix:** check identity against the sentinel instead of truthiness — `if loc is not None:` — so index `0` is correctly treated as a valid match while `None` ("no match found") still skips the delete.

This is a pure bug fix with no behaviour change for any non-zero match.

### Verification
- `python -m py_compile website/app/history/history_core.py` — clean.
- `website/` has no automated test coverage in this repository; verification was py_compile plus running the module test suite, which still passes: 161 passed, 4 skipped, 5 subtests passed in 35.18s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

