### PR TITLE
[medium] fix: [website] fix IS_DEVELOPMENT rebind so dev admin password generates

### DIFF
--- a/website/main.py
+++ b/website/main.py
@@ -31,16 +31,16 @@ def run_dev():
         )
         time.sleep(2)
 
-    from app.utils import IS_DEVELOPMENT
+    import app.utils.utils as utils
 
-    IS_DEVELOPMENT = True
+    utils.IS_DEVELOPMENT = True
 
     try:
         print("Starting website in debug mode...")
         app.run(
             host=app.config["FLASK_URL"],
             port=app.config["FLASK_PORT"],
-            debug=IS_DEVELOPMENT,
+            debug=utils.IS_DEVELOPMENT,
         )
     finally:
         if os.getenv("WERKZEUG_RUN_MAIN") != "true":


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `run_dev()` rebound a local `IS_DEVELOPMENT`, so the dev admin password was never generated.

- **Problem** — `run_dev()` in `website/main.py` does `from app.utils import IS_DEVELOPMENT` then reassigns the name, which rebinds only `main.py`'s local copy and never the global in `app/utils/utils.py` that `gen_admin_password()` reads.
- **Fix** — Import the submodule directly and set `utils.IS_DEVELOPMENT`, and point the `app.run(debug=)` kwarg at the same attribute.
- **Effect** — Operators starting a local dev instance without `ADMIN_PASSWORD` again get an auto-generated admin password printed, instead of having no way to log in. The change is scoped to `run_dev()`, never invoked in production.
<!-- /bluf -->

`website/main.py`'s `run_dev()` did:

```python
from app.utils import IS_DEVELOPMENT

IS_DEVELOPMENT = True
```

`from app.utils import IS_DEVELOPMENT` binds a local name `IS_DEVELOPMENT` in `main.py`'s own module namespace. The following `IS_DEVELOPMENT = True` only rebinds that local — it never touches the module-level global `IS_DEVELOPMENT` in `app/utils/utils.py`, which is the one `gen_admin_password()` actually reads (`if IS_DEVELOPMENT:` at `app/utils/utils.py:84`). Since `gen_admin_password` is defined inside `app/utils/utils.py`, its global scope resolves against that submodule's `__dict__`, not against `app.utils`'s re-exported copy — so even `app.utils.IS_DEVELOPMENT = True` would not have worked either, since that's a separate binding created by `app/utils/__init__.py`'s own `from .utils import IS_DEVELOPMENT`.

**Impact:** Running the MISP modules website in dev mode (`run_dev()`) with no `ADMIN_PASSWORD` env var set is supposed to auto-generate and print a development admin password. Because of this rebind bug, `gen_admin_password()` always sees `IS_DEVELOPMENT` as `False`, so no password is ever generated or printed — an operator standing up a local dev instance gets no way to log in as admin.

**Fix:** Import the submodule directly — `import app.utils.utils as utils` — and set `utils.IS_DEVELOPMENT = True`, so the assignment lands on the actual global that `gen_admin_password()` reads. The `debug=` kwarg passed to `app.run()` is updated to reference `utils.IS_DEVELOPMENT` since the old local name no longer exists.

**Behaviour change:** This restores the code's evident intent rather than introducing new behaviour — the `IS_DEVELOPMENT` flag exists solely to trigger this auto-generate-password path, and the change is scoped entirely to `run_dev()`, which is never invoked in production.

### Verification

`website/` has no automated test coverage in this repository. Verification was:
- `python -m py_compile website/main.py`: clean
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 25.71s`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

