### PR TITLE
[critical] fix: [website] register state-changing routes as POST, not GET

### DIFF
--- a/website/app/history/history.py
+++ b/website/app/history/history.py
@@ -86,13 +86,13 @@ def get_history_session_uuid(sid):
     return {}
 
 
-@history_blueprint.route("/history/remove_node_session/<sid>", methods=["GET"])
+@history_blueprint.route("/history/remove_node_session/<sid>", methods=["POST"])
 def remove_node_session(sid):
     HistoryModel.remove_node_session(sid)
     return {"message": "Node deleted", "toast_class": "success-subtle"}
 
 
-@history_blueprint.route("/history/remove_node_tree/<sid>", methods=["GET"])
+@history_blueprint.route("/history/remove_node_tree/<sid>", methods=["POST"])
 def remove_node_tree(sid):
     HistoryModel.remove_node_tree(sid)
     return {"message": "Node deleted", "toast_class": "success-subtle"}

--- a/website/app/home.py
+++ b/website/app/home.py
@@ -279,7 +279,7 @@ def change_config():
     return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
 
 
-@home_blueprint.route("/change_status", methods=["GET"])
+@home_blueprint.route("/change_status", methods=["POST"])
 def change_status():
     """Change the status of a module, active or unactive"""
     sess["admin_user"] = admin_user_active()

--- a/website/app/static/js/history/history_view.js
+++ b/website/app/static/js/history/history_view.js
@@ -10,12 +10,18 @@ export default {
 	emits: ['delete_node'],
 	setup(props, {emit}) {
 		async function remove_node(history_uuid){
-			const res = await fetch('/history/remove_node_session/' + history_uuid)
+			const res = await fetch('/history/remove_node_session/' + history_uuid, {
+								headers: { "X-CSRFToken": $("#csrf_token").val() },
+								method: "POST",
+							})
 			display_toast(res)
 			emit('delete_node', true)
 		}
 		async function remove_node_tree(history_uuid){
-			const res = await fetch('/history/remove_node_tree/' + history_uuid)
+			const res = await fetch('/history/remove_node_tree/' + history_uuid, {
+								headers: { "X-CSRFToken": $("#csrf_token").val() },
+								method: "POST",
+							})
 			display_toast(res)
 			emit('delete_node', true)
 		}

--- a/website/app/templates/history_session.html
+++ b/website/app/templates/history_session.html
@@ -116,12 +116,18 @@
             }
 
             async function remove_node(history_loc, key){
-                const res = await fetch('/history/remove_node_session/' + history_loc.uuid)
+                const res = await fetch('/history/remove_node_session/' + history_loc.uuid, {
+                                    headers: { "X-CSRFToken": $("#csrf_token").val() },
+                                    method: "POST",
+                                })
                 display_toast(res)
                 await change_tree(history_loc, key)
             }
             async function remove_node_tree(history_loc, key){
-                const res = await fetch('/history/remove_node_tree/' + history_loc.uuid)
+                const res = await fetch('/history/remove_node_tree/' + history_loc.uuid, {
+                                    headers: { "X-CSRFToken": $("#csrf_token").val() },
+                                    method: "POST",
+                                })
                 display_toast(res)
                 await change_tree(history_loc, key)
             }

--- a/website/app/templates/modules_config.html
+++ b/website/app/templates/modules_config.html
@@ -139,7 +139,10 @@
             }
 
             async function change_status(module){
-                let res = await fetch("/change_status?module_id="+module.id)
+                let res = await fetch("/change_status?module_id="+module.id, {
+                                    headers: { "X-CSRFToken": $("#csrf_token").val() },
+                                    method: "POST",
+                                })
                 if(await res.status_code == 200){
                     module.is_active = !module.is_active
                 }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Three state-changing website routes were GET and thus unprotected by CSRF; they are now POST.

- **Problem** — `/change_status` in `website/app/home.py` and `/history/remove_node_session` and `/history/remove_node_tree` in `website/app/history/history.py` are registered as GET, and Flask-WTF's `CSRFProtect` only validates unsafe methods, so they carry no CSRF protection at all.
- **Fix** — Re-register the three routes as POST and update their callers in `modules_config.html`, `history_session.html` and `history_view.js` to send the `X-CSRFToken` header.
- **Effect** — An admin who visits a hostile page can no longer have a module silently toggled or a history node deleted by a cross-site request; parameters, handler logic and responses are unchanged.
<!-- /bluf -->

Three state-changing Flask routes were registered as `GET`, but Flask-WTF's `CSRFProtect` only validates "unsafe" HTTP methods (POST/PUT/PATCH/DELETE) by default and leaves GET requests unchecked:

```python
@home_blueprint.route("/change_status", methods=["GET"])
def change_status():
    ...

@history_blueprint.route("/history/remove_node_session/<sid>", methods=["GET"])
def remove_node_session(sid):
    ...

@history_blueprint.route("/history/remove_node_tree/<sid>", methods=["GET"])
def remove_node_tree(sid):
    ...
```

Because these are simple `GET` requests, they are trivially triggerable cross-site — e.g. via `<img src="https://target/change_status?module_id=...">` embedded on an attacker-controlled page — bypassing CSRF protection entirely.

**Impact:** A logged-in MISP-modules website admin who visits a malicious page (or one with attacker-controlled content) can have a module silently disabled/enabled, or a history session/tree node silently deleted, without any interaction or confirmation, and without the CSRF token check that protects the equivalent `POST` routes (e.g. `/change_config`).

**Fix:** Changed the three routes to `methods=["POST"]` so CSRFProtect actually covers them, matching the existing pattern used by `/change_config`. Updated the corresponding JS/template callers (`modules_config.html`, `history_session.html`, `history_view.js`) to issue `POST` requests with the `X-CSRFToken` header instead of plain `GET` fetches.

This is a behaviour change only in HTTP method (GET → POST) for these three endpoints; the request parameters, handler logic, and responses are unchanged, and all callers in the codebase were updated to match.

### Verification

The `website/` app has no automated test coverage in this repository. Verification was:
- `py_compile` clean on `website/app/home.py` and `website/app/history/history.py`
- JS/HTML template edits re-read carefully for correctness
- Full module test suite still passing: `161 passed, 4 skipped, 5 subtests passed in 74.97s (0:01:14)` — matches baseline

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

