### PR TITLE
[critical] fix: [website] stop injecting attribute values into inline onclick strings

### DIFF
--- a/website/app/static/js/mispParser.js
+++ b/website/app/static/js/mispParser.js
@@ -13,14 +13,15 @@ function parseMispObject(misp_object, query_url, functionToCall){
                                 .css("margin-left", "10px")
                 }
                 if(functionToCall){
-                    // `_${functionToCall.name}('${v.value}')` refer to 'window._query_as_same = query_as_same' in my vue file
-                    $query_same = $("<button>").attr({"onclick": `_${functionToCall.name}('${v.value}')`, 
+                    // refer to 'window._query_as_same = query_as_same' in my vue file
+                    $query_same = $("<button>").attr({
                                 "title": "Query this value with the same attribute and modules as the main query",
                                 "class": "btn btn-link"
                                 })
                             // .text("query as same")
                             .append($("<i>").attr("class", "fa-solid fa-recycle"))
                             .css({"margin-left": "10px", "padding": "0", "--bs-btn-border-width": "0"})
+                            .on("click", function(){ window[`_${functionToCall.name}`](v.value) })
                 }
             }
             
@@ -78,14 +79,15 @@ function parseMispAttr(misp_attr, misp_types, key, query_url, query_as_same){
         if(query_url){
             $query=$("<a>").attr("href", query_url+misp_attr).text("query").css("margin-left", "10px")
         }
-        // `_${functionToCall.name}('${misp_attr}')` refer to 'window._query_as_same = query_as_same' in my vue file
+        // refer to 'window._query_as_same = query_as_same' in my vue file
         if(query_as_same){
-            $query_same = $("<button>").attr({"onclick": `_${query_as_same.name}('${misp_attr}')`, 
+            $query_same = $("<button>").attr({
                             "title": "Query this value with the same attribute and modules as the main query",
                             "class": "btn btn-link"
                         })
                     .text("query as same")
                     .css({"margin-left": "10px", "padding": "0", "--bs-btn-border-width": "0"})
+                    .on("click", function(){ window[`_${query_as_same.name}`](misp_attr) })
         }
     }
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `mispParser.js` spliced attribute values into `onclick`, a stored XSS; now a bound handler.

- **Problem** — In `website/app/static/js/mispParser.js`, both `parseMispObject` and `parseMispAttr` build their query-as-same buttons by interpolating a MISP attribute value straight into an `onclick` attribute string, so any value containing a quote or backtick executes as JavaScript in the analyst's browser.
- **Fix** — Bind a click handler with `.on("click", ...)` that receives the value through a closure, so it is passed as a JS value and never parsed as attribute-embedded source.
- **Effect** — An attacker who plants a crafted value in a shared event or feed can no longer achieve **stored XSS** against every analyst who views it; the button still calls the same function with the same argument.
<!-- /bluf -->

### The defect

`website/app/static/js/mispParser.js` built the "query as same" button by string-interpolating an attribute value directly into an `onclick` attribute:

```js
// parseMispObject/generate, line ~17
$query_same = $("<button>").attr({"onclick": `_${functionToCall.name}('${v.value}')`, ...})

// parseMispAttr, line ~84
$query_same = $("<button>").attr({"onclick": `_${query_as_same.name}('${misp_attr}')`, ...})
```

`v.value` / `misp_attr` come from MISP attribute data being displayed, and are spliced unescaped into an executable JS attribute string. Any attribute value containing a single quote, backtick, or other JS-breaking characters is executed verbatim as JavaScript in the analyst's browser when the element is rendered.

### Impact

An attacker who can get a malicious MISP attribute value into a shared/queried event (or feed) can execute arbitrary JavaScript in the browser of any MISP analyst who views that attribute through this query UI — a stored XSS vector, not merely self-XSS.

### The fix

Both sites now build the button without ever passing the value through an interpolated attribute string. Instead, a `.on("click", function(){ window[`_${name}`](value) })` handler reads the value directly from the closure/parameter, so it is used as a JS value, never parsed as attribute-embedded source text — closing the injection vector regardless of what characters the value contains.

This is a pure defect fix with no behavior change: the button still calls the same `window._<name>(value)` function with the same value on click.

Note: the finding that prompted this also proposed an ownership check on the Flask `/query/<sid>` route (`website/app/home.py`). That file is intentionally untouched here — it's outside the file this fix targets, and adding real ownership checking would require inventing a user/session association model that doesn't currently exist in `HomeModel`/`SessionModel`, which is a larger design change out of scope for this minimal fix.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

The `website/` app has no automated test coverage in this repository. Verification was manual diff review of both call sites plus confirming the closure variable (`v`, a `forEach` callback parameter, and `misp_attr`, a function parameter) is correctly scoped per-iteration/per-call so no stale-value regression is introduced. The misp-modules module test suite was also run and is unaffected by this change: `161 passed, 4 skipped, 5 subtests passed in 20.32s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

