### PR TITLE
[low] fix: [qintel_helper] add missing f-prefix to rate-limit log message

### DIFF
--- a/misp_modules/lib/qintel_helper.py
+++ b/misp_modules/lib/qintel_helper.py
@@ -80,7 +80,7 @@ def _search(**kwargs):
             wait_time = _get_request_wait_time(request_attempts)
 
             if response.code == 429:
-                msg = "rate limit reached on attempt {request_attempts}, waiting {wait_time} seconds"
+                msg = f"rate limit reached on attempt {request_attempts}, waiting {wait_time} seconds"
 
                 if logger:
                     logger(msg)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The Qintel 429 log line was missing its `f` prefix, so it printed raw placeholders.

- **Problem** — The rate-limit handler in `misp_modules/lib/qintel_helper.py` builds its message from a plain string literal, so `{request_attempts}` and `{wait_time}` are logged verbatim rather than interpolated.
- **Fix** — Add the missing `f` prefix to that message; a one-line change with no behavior change beyond the log text.
- **Effect** — Operators debugging Qintel API throttling see the real retry count and backoff duration in the log instead of placeholder text.
<!-- /bluf -->

The 429 rate-limit log message in `qintel_helper.py` was a plain string literal, not an f-string:

```python
if response.code == 429:
    msg = "rate limit reached on attempt {request_attempts}, waiting {wait_time} seconds"
```

Because the `f` prefix was missing, the `{request_attempts}` and `{wait_time}` placeholders were never interpolated — the log line prints the literal text `{request_attempts}` and `{wait_time}` instead of the actual attempt number and wait time.

**Impact:** When the Qintel enrichment module hits the Qintel API's rate limit, the log message an analyst or operator relies on to understand and debug the throttling behavior is useless — it shows placeholder text instead of which attempt this is and how long the module is waiting before retrying.

**Fix:** Added the missing `f` prefix so the log line correctly interpolates `request_attempts` and `wait_time`. This is a one-line change with no behavior change beyond the log text now being correct.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `py_compile misp_modules/lib/qintel_helper.py`: OK
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 24.76s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

