### PR TITLE
[critical] fix: [vmray] stop disabling TLS certificate verification

### DIFF
--- a/misp_modules/lib/_vmray/parser.py
+++ b/misp_modules/lib/_vmray/parser.py
@@ -1066,7 +1066,8 @@ class VMRayParser:
         except ValueError:
             raise VMRayParseError("Could not convert sample id to integer.")
 
-        self.api = VMRayRESTAPI(url, api_key, False)
+        verify_cert = not self._config_from_string(config.get("disable_certificate_verification"))
+        self.api = VMRayRESTAPI(url, api_key, verify_cert)
 
         self.ignore_analysis_finished = self._config_from_string(config.get("ignore_analysis_finished"))
         self._setup_optional_config(config)

--- a/misp_modules/modules/expansion/vmray_submit.py
+++ b/misp_modules/modules/expansion/vmray_submit.py
@@ -50,6 +50,7 @@ moduleconfig = [
     "shareable",
     "do_not_reanalyze",
     "do_not_include_vmrayjobids",
+    "disable_certificate_verification",
 ]
 
 
@@ -90,19 +91,21 @@ def handler(q=False):
         misperrors["error"] = "Missing API key or server URL (hint: try cloud.vmray.com)"
         return misperrors
 
-    api = VMRayRESTAPI(request["config"].get("url"), request["config"].get("apikey"), False)
-
     shareable = request["config"].get("shareable")
     do_not_reanalyze = request["config"].get("do_not_reanalyze")
     do_not_include_vmrayjobids = request["config"].get("do_not_include_vmrayjobids")
+    disable_certificate_verification = request["config"].get("disable_certificate_verification")
 
     try:
         shareable = bool(strtobool(shareable))  # Do we want the sample to be shared?
         reanalyze = not bool(strtobool(do_not_reanalyze))  # Always reanalyze the sample?
         include_vmrayjobids = not bool(strtobool(do_not_include_vmrayjobids))  # Include the references to VMRay job IDs
+        verify_cert = not bool(strtobool(disable_certificate_verification))  # Verify the server's TLS certificate?
     except ValueError:
         misperrors["error"] = "Error while processing settings. Please double-check your values."
         return misperrors
+
+    api = VMRayRESTAPI(request["config"].get("url"), request["config"].get("apikey"), verify_cert)
 
     if data and sample_filename:
         args = {}

--- a/misp_modules/modules/import_mod/vmray_import.py
+++ b/misp_modules/modules/import_mod/vmray_import.py
@@ -68,6 +68,7 @@ moduleconfig = [
     "disable_tags",
     "disable_misp_objects",
     "ignore_analysis_finished",
+    "disable_certificate_verification",
 ]
 
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The VMRay modules disabled TLS verification unconditionally; it is now on by default.

- **Problem** — `vmray_submit.py` and the shared `_vmray` parser hardcode `verify_cert=False` on every VMRay API call, so report fetches and sample submissions — including the API key and the malware sample itself — run over TLS that is never validated, with no config option to re-enable checking.
- **Fix** — Add a `disable_certificate_verification` moduleconfig key to both modules and default certificate verification on.
- **Effect** — Analysts using `vmray_import` or `vmray_submit` are no longer silently exposed to man-in-the-middle interception of the API key and submitted samples.
- **Cost** — A deliberate default flip: deployments pointing at a self-signed VMRay instance must now set `disable_certificate_verification` to keep working.
<!-- /bluf -->

Both `vmray_submit.py` and `vmray_import.py` (via `parser.py`'s `VMRayParser.from_api`) hardcoded TLS certificate verification off for every VMRay API call:

```python
# lib/_vmray/parser.py:1069
self.api = VMRayRESTAPI(url, api_key, False)

# modules/expansion/vmray_submit.py:93
api = VMRayRESTAPI(request["config"].get("url"), request["config"].get("apikey"), False)
```

`VMRayRESTAPI` defaults `verify_cert=True` (`lib/_vmray/rest_api.py:41`), but both call sites explicitly override it to `False`, with no config option to turn it back on. Every report fetch and every sample submission is affected — and submission uploads the malware sample itself plus the API key over that unverified connection.

**Impact:** an analyst using either the `vmray_import` or `vmray_submit` module is silently exposed to man-in-the-middle interception/tampering on every request to VMRay, including exfiltration of the API key and the submitted sample, with no way to opt back into certificate checking.

**Fix:** added a `disable_certificate_verification` moduleconfig key to both modules, following the codebase's existing `disable_tags`/`disable_misp_objects` boolean-config pattern. Certificate verification now defaults to `True` (safe) and can only be disabled via explicit opt-in, for the rare self-signed-deployment case.

**Behaviour change:** this flips the default from "verification disabled" to "verification enabled." This is a deliberate security-default fix — any deployment relying on the previous silent bypass (e.g. against a self-signed VMRay instance) must now set `disable_certificate_verification` to keep working; that is the intended trade-off for closing an unauthenticated MITM exposure by default.

### Verification

- `flake8` clean on the two changed module files; `py_compile` clean on `lib/_vmray/parser.py`.
- Full module test suite: 160 passed, 1 failed, 4 skipped, 5 subtests passed (the failure was `test_macvendors`, an HTTP 429 rate limit from a third-party API unrelated to vmray, and it passed on an isolated retry). No vmray-specific tests exist in the suite.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

