### PR TITLE
[high] fix: avoid mutable default for qsentry_feed date

### DIFF
--- a/misp_modules/lib/qintel_helper.py
+++ b/misp_modules/lib/qintel_helper.py
@@ -231,7 +231,7 @@ def search_qsentry(search_term, **kwargs):
     return loads(_search(**kwargs).read())
 
 
-def qsentry_feed(query_type="anon", feed_date=datetime.today(), **kwargs):
+def qsentry_feed(query_type="anon", feed_date=None, **kwargs):
     """
     Fetch the most recent QSentry Feed
 
@@ -245,6 +245,8 @@ def qsentry_feed(query_type="anon", feed_date=datetime.today(), **kwargs):
     remote = _set_remote("qsentry_feed", query_type, **kwargs)
     kwargs["token"] = kwargs.get("token", os.getenv("QSENTRY_TOKEN"))
 
+    if feed_date is None:
+        feed_date = datetime.today()
     feed_date = (feed_date - timedelta(days=1)).strftime("%Y%m%d")
     kwargs["remote"] = f"{remote}/{feed_date}"
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `qsentry_feed()` froze its default feed date at import; it is now computed per call.

- **Problem** — `qsentry_feed()` in `misp_modules/lib/qintel_helper.py` declares `feed_date=datetime.today()`, which is evaluated once at import and frozen for the life of the process.
- **Fix** — Default `feed_date` to `None` and compute `datetime.today()` inside the function body when no date is supplied.
- **Effect** — In a long-running misp-modules server, callers that omit `feed_date` get the current day's QSentry feed instead of silently fetching the feed for the day the process started. No behaviour change for callers passing an explicit date.
<!-- /bluf -->

`qsentry_feed()` in `misp_modules/lib/qintel_helper.py` uses a mutable/eager default argument:

```python
def qsentry_feed(query_type="anon", feed_date=datetime.today(), **kwargs):
```

`datetime.today()` is evaluated exactly once, at module import time, and that value is baked into the function's default forever. In a long-running server process (which is exactly how misp-modules runs), every call to `qsentry_feed()` that relies on the default `feed_date` keeps using the date the process started, not the date the call actually happens on.

**Impact:** an analyst or integration calling `qsentry_feed()` without an explicit `feed_date` on a server that has been up for more than a day gets the QSentry feed for a stale date, silently, until the process is restarted.

**Fix:** default `feed_date` to `None` and compute `datetime.today()` inside the function body when no date is supplied, so the date is evaluated per-call instead of at import time.

No behaviour change for callers that explicitly pass `feed_date`; callers relying on the default now get the correct current date instead of a frozen one, which is the intended/correct behaviour.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `python -m py_compile misp_modules/lib/qintel_helper.py`: clean (this file is under `misp_modules/lib/`, excluded from flake8 per CI rules).
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 20.58s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

