### PR TITLE
[high] fix: [malshare_upload] avoid KeyError when config is missing

### DIFF
--- a/misp_modules/modules/expansion/malshare_upload.py
+++ b/misp_modules/modules/expansion/malshare_upload.py
@@ -47,7 +47,7 @@ def handler(q=False):
         misperrors["error"] = "Unable to process submitted sample data"
         return misperrors
 
-    if request["config"].get("malshare_apikey") is None:
+    if (request.get("config") or {}).get("malshare_apikey") is None:
         misperrors["error"] = "Missing MalShare API key"
         return misperrors
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `malshare_upload.py` raises `KeyError` on a config-less request instead of its missing-key message.

- **Problem** — `malshare_upload.py` indexes `request["config"]` directly, so a request carrying no `config` key at all raises an unhandled `KeyError` instead of the module's intended "Missing MalShare API key" message.
- **Fix** — Reads `(request.get("config") or {}).get("malshare_apikey")` so the friendly error is returned.
- **Effect** — Analysts who run the module before a MalShare API key is configured now get a clear setup message rather than a traceback surfaced through MISP.
<!-- /bluf -->

```python
if request["config"].get("malshare_apikey") is None:
```

Direct indexing into `request["config"]` raises a `KeyError` whenever the incoming request has no `"config"` key at all, instead of returning the module's intended friendly error message `"Missing MalShare API key"`.

**Impact:** An analyst who invokes the `malshare_upload` expansion module without any configuration (e.g. no MalShare API key set up in MISP module settings, so `config` is entirely absent from the request) gets an unhandled `KeyError` traceback surfaced back through MISP instead of a clear "Missing MalShare API key" error explaining what to fix.

**Fix:** Changed the lookup to `(request.get("config") or {}).get("malshare_apikey")`, which falls back to an empty dict when `"config"` is missing, so the friendly error message is returned as intended.

### Verification

- `flake8 misp_modules/modules/expansion/malshare_upload.py` — clean (no output)
- Full test suite: `161 passed, 4 skipped, 5 subtests passed in 25.92s`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

