### PR TITLE
[high] fix: [reversinglabs_spectra_analyze] parse dns child-key limit for obj:path branch

### DIFF
--- a/misp_modules/modules/expansion/reversinglabs_spectra_analyze.py
+++ b/misp_modules/modules/expansion/reversinglabs_spectra_analyze.py
@@ -2539,6 +2539,11 @@ def _process_object_recursive(
             if not foreach_path:
                 foreach_path = obj_path_value.strip()
 
+            # The limit is encoded on the child key (e.g. "dns-ips[10]"), not on obj:path
+            _, _, _, _, key_limit = _parse_obj_key(child_key)
+            if key_limit != MAX_FOREACH_ITERATIONS:
+                foreach_limit = key_limit
+
             # Get the data at the path
             path_data = get_first(data, [foreach_path])
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `reversinglabs_spectra_analyze` reads the child cap from the wrong key, so declared caps are ignored.

- **Problem** — In `_process_object_recursive`, the `obj:path` branch of `reversinglabs_spectra_analyze.py` parses the per-field child limit out of `obj:path`, which never carries a numeric cap; the cap is declared on the child key in `MAPPING_RULES`, such as `dns-ips[10]`. The limit stayed at its sentinel default and truncation fell back to `MAX_DNS_CHILDREN` (25).
- **Fix** — Also parses `child_key` with `_parse_obj_key`, mirroring the `foreach` branch.
- **Effect** — Mapping rules declaring a cap below 25 now emit the intended number of child objects.
<!-- /bluf -->

In `_process_object_recursive`, the `obj:path` branch (`misp_modules/modules/expansion/reversinglabs_spectra_analyze.py`, ~line 2536) parsed the per-field child limit from the wrong string:

```python
_, _, foreach_path, foreach_filter, foreach_limit = _parse_obj_key(obj_path_value)

if not foreach_path:
    foreach_path = obj_path_value.strip()
```

`obj_path_value` comes from `child_def.get("obj:path")`, e.g. `"last_dns_records[type=A,AAAA]"` — it never carries a numeric cap. The numeric cap (e.g. `"[10]"`) is instead encoded on the *child object's key* in `MAPPING_RULES`, e.g. `"dns-ips[10]": { "obj:type": "ip-port", "obj:path": "last_dns_records[type=A,AAAA]", ... }`. Since `_parse_obj_key` was never called on `child_key` in this branch, `foreach_limit` stayed at the sentinel default (`MAX_FOREACH_ITERATIONS`), and the truncation logic a few lines below then silently fell back to `MAX_DNS_CHILDREN` (25) instead of the declared 10. The sibling `foreach`-key branch a few lines below (~line 2638) already parses `child_key` correctly and was not affected.

### Impact

For any mapping rule using the `obj:path` directive with a declared per-field cap smaller than 25 (e.g. `dns-ips[10]`), an analyst enriching an object from ReversingLabs Spectra Analyze would receive up to 25 child objects (e.g. DNS IP records) instead of the intended 10 — noisier, larger objects than the mapping rule author intended, with no truncation notice reflecting the real limit.

### Fix

Also parse `child_key` with `_parse_obj_key` in the `obj:path` branch and use its explicit limit when present, mirroring the sibling `foreach`-key branch that already does this correctly. This changes observable output only for fields whose mapping declares a limit below the 25-item default: those fields now correctly truncate at their declared cap instead of silently allowing up to 25 children.

### Verification

- `python -m py_compile misp_modules/modules/expansion/reversinglabs_spectra_analyze.py` — clean.
- `flake8 misp_modules/modules/expansion/reversinglabs_spectra_analyze.py` — clean (exit 0).
- Started the misp-modules server locally (`python -m misp_modules -l 127.0.0.1 -p 6666`) and ran the full test suite: `python -m pytest tests/ -q` → `161 passed, 4 skipped, 5 subtests passed in 10.17s`.
- Sanity-checked the parser directly: `_parse_obj_key("dns-ips[10]")` → `('dns-ips', [], 'dns-ips', None, 10)`, confirming the limit is now correctly extracted from the child key.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

