### PR TITLE
[medium] fix: [reversedns] fix nameserver fallback when config is an empty dict

### DIFF
--- a/misp_modules/modules/expansion/reversedns.py
+++ b/misp_modules/modules/expansion/reversedns.py
@@ -49,13 +49,7 @@ def handler(q=False):
     r = resolver.Resolver()
     r.timeout = 2
     r.lifetime = 2
-    if request.get("config"):
-        if request["config"].get("nameserver"):
-            nameservers = []
-            nameservers.append(request["config"].get("nameserver"))
-            r.nameservers = nameservers
-    else:
-        r.nameservers = ["8.8.8.8"]
+    r.nameservers = [(request.get("config") or {}).get("nameserver") or "8.8.8.8"]
 
     try:
         answer = r.resolve(revname, "PTR")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `reversedns.py` skips its documented 8.8.8.8 fallback when `config` is present but empty.

- **Problem** — `reversedns.py` falls back to Google DNS only when the `config` key is absent entirely; if `config` is present but empty or lacks `nameserver`, neither branch sets `r.nameservers` and the resolver silently uses the host's system DNS.
- **Fix** — Collapses the `if`/`else` into one expression that falls back to `8.8.8.8` whenever `config` or `config.nameserver` is missing or empty.
- **Effect** — PTR enrichment for requests like `{"config": {}}` becomes predictable instead of environment-dependent.
<!-- /bluf -->

The reversedns module's documented fallback to Google DNS only triggers when the `config` key is missing entirely:

```python
if request.get("config"):
    if request["config"].get("nameserver"):
        nameservers = []
        nameservers.append(request["config"].get("nameserver"))
        r.nameservers = nameservers
else:
    r.nameservers = ["8.8.8.8"]
```

If `config` is present but empty or lacks `nameserver` (e.g. `{"config": {}}`), neither branch sets `r.nameservers`, so the resolver silently falls back to the system's default nameservers instead of the documented `8.8.8.8` fallback.

An analyst who submits `{"config": {}}` (a common case when a config dict is built but not yet populated, or when only unrelated config keys are set) gets PTR lookups resolved through whatever DNS servers the host happens to use, rather than the documented, predictable `8.8.8.8`. This can produce inconsistent or environment-dependent enrichment results, and is surprising given the module's documented behavior.

## Fix

Replaced the if/else block with a single expression that falls back to `8.8.8.8` whenever `config` is absent, `config.nameserver` is absent, or either is empty/falsy:

```python
r.nameservers = [(request.get("config") or {}).get("nameserver") or "8.8.8.8"]
```

This is a pure bug fix restoring the module's already-documented fallback behavior; it does not change the documented contract.

### Verification

- `python -m py_compile misp_modules/modules/expansion/reversedns.py` — succeeded.
- `flake8` on the changed file — clean (no output).
- Full module test suite — 161 passed, 4 skipped, 5 subtests passed in 23.42s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

