### PR TITLE
fix: [geoip_country] guard against malformed domain|ip composite value

### DIFF
--- a/misp_modules/modules/expansion/geoip_country.py
+++ b/misp_modules/modules/expansion/geoip_country.py
@@ -49,7 +49,10 @@ def handler(q=False):
     elif request.get("ip-src"):
         toquery = request["ip-src"]
     elif request.get("domain|ip"):
-        toquery = request["domain|ip"].split("|")[1]
+        parts = request["domain|ip"].split("|")
+        if len(parts) != 2:
+            return {"error": "Invalid domain|ip composite attribute."}
+        toquery = parts[1]
     else:
         return False
 


### PR DESCRIPTION
The `domain|ip` handling in `geoip_country.py` splits the composite attribute value and blindly indexes into the result:

```python
elif request.get("domain|ip"):
    toquery = request["domain|ip"].split("|")[1]
```

If `request["domain|ip"]` does not contain a `|` separator (a malformed or unexpected composite value), `split("|")` returns a single-element list and `[1]` raises an unhandled `IndexError`.

**Impact:** an analyst enriching a malformed `domain|ip` attribute gets an unhandled Python traceback surfaced through the module framework instead of the clean, expected `{"error": ...}` response MISP shows for other invalid-input cases in this same module.

**Fix:** split the value, verify it produced exactly two parts, and return a friendly `{"error": "Invalid domain|ip composite attribute."}` dict otherwise — matching the module's existing error-response style. No behaviour change for well-formed input; malformed input now fails gracefully instead of crashing.

### Verification

- `flake8 misp_modules/modules/expansion/geoip_country.py` — clean (no output)
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 23.88s`

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
