### PR TITLE
[high] fix: [btc_steroids] filter output transactions on their own value field

### DIFF
--- a/misp_modules/modules/expansion/btc_steroids.py
+++ b/misp_modules/modules/expansion/btc_steroids.py
@@ -206,7 +206,7 @@ def handler(q=False):
                     except KeyError:
                         addr_out = None
                     try:
-                        prev_out = tx["prev_out"]["value"]
+                        prev_out = tx["value"]
                     except KeyError:
                         prev_out = None
                     if prev_out != 0 and addr_out == btc:


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `btc_steroids` reads `prev_out` on output entries, so its zero-value filter never excludes anything.

- **Problem** — The output loop in `btc_steroids.py` reads `tx["prev_out"]["value"]`, but `prev_out` exists only on input entries, so the lookup always raises `KeyError` and the zero-value filter never excludes anything.
- **Fix** — Reads `tx["value"]`, the field actually present on `out` entries and already used to compute the displayed value.
- **Effect** — Analysts enriching a bitcoin address now get real payments without zero-value `OP_RETURN` and dust outputs cluttering the enrichment result.
<!-- /bluf -->

In `btc_steroids.py`, the loop over output transactions reads `tx["prev_out"]["value"]`:

```python
for tx in transactions["out"]:
    ...
    try:
        prev_out = tx["prev_out"]["value"]
    except KeyError:
        prev_out = None
    if prev_out != 0 and addr_out == btc:
```

Entries in `transactions["out"]` never have a `prev_out` key — that field belongs to the input entries handled in the loop above (`transactions["inputs"]`). So the lookup always raises `KeyError`, `prev_out` is always set to `None`, and `prev_out != 0` is always `True`. The zero-value filter therefore never filters anything.

**Impact:** an analyst enriching a bitcoin address/transaction via the `btc_steroids` expansion module gets zero-value outputs (e.g. OP_RETURN or dust outputs with `value == 0`) listed alongside real payments, cluttering the enrichment result with entries the filter was meant to exclude.

**Fix:** read `tx["value"]` directly, which is the field actually present on `out` entries (and is already the field used a few lines below to compute and print the displayed value), so the zero-value filter now works as intended.

No behaviour change beyond restoring the intended filtering (fewer, correctly-filtered lines in output; no API or module contract change).

### Verification
- `flake8` on the changed file: clean, no output.
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 32.77s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

