### PR TITLE
[low] fix: [export_mod/goamlexport] fix typo'd dict name in introspection()

### DIFF
--- a/misp_modules/modules/export_mod/goamlexport.py
+++ b/misp_modules/modules/export_mod/goamlexport.py
@@ -352,7 +352,7 @@ def introspection():
         pass
     try:
         inputSource
-        moduleSetup["inputSource"] = inputSource
+        modulesetup["inputSource"] = inputSource
     except NameError:
         pass
     return modulesetup


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `introspection()` in `goamlexport.py` writes to `moduleSetup`, a dict name that exists nowhere.

- **Problem** — The `introspection()` function in `goamlexport.py` assigns to `moduleSetup`, a name that exists nowhere in the function; the dict actually built and returned is `modulesetup`.
- **Fix** — Corrects the identifier so the assignment targets the real dict, matching the three sibling `try`/`except NameError` blocks.
- **Effect** — There is no current behaviour change: the preceding bare `inputSource` reference raises `NameError` first, so the line is unreachable today. The fix only prevents `introspection()` from crashing if `inputSource` is ever defined at module scope.
<!-- /bluf -->

`misp_modules/modules/export_mod/goamlexport.py`'s `introspection()` has a typo that writes to the wrong dict name:

```python
try:
    inputSource
    moduleSetup["inputSource"] = inputSource
except NameError:
    pass
return modulesetup
```

`moduleSetup` (capital `S`) does not exist anywhere in the function — the dict actually built and returned is `modulesetup`. Today this is latent: the bare `inputSource` reference on the preceding line raises `NameError` first (since `inputSource` is never defined at module scope), so the buggy assignment is never reached. But if `inputSource` were ever defined at module scope, the function would crash with `NameError: name 'moduleSetup' is not defined` instead of returning module setup info, breaking `introspection()` for this export module and anything depending on its output (e.g. the misp-modules server's module listing).

**Fix:** changed `moduleSetup` to `modulesetup` so the assignment targets the dict that is actually built and returned, matching the pattern used by the other three `try/except NameError` blocks in the same function.

No behaviour change for the current codebase (the branch is unreachable as written); this only prevents a future crash if `inputSource` is ever added.

### Verification

- `flake8` on the changed file: clean (exit 0)
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 27.64s

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

