### PR TITLE
[medium] fix: [import_mod/ocr] guard against zero-page PDFs

### DIFF
--- a/misp_modules/modules/import_mod/ocr.py
+++ b/misp_modules/modules/import_mod/ocr.py
@@ -69,6 +69,9 @@ def handler(q=False):
             # Get number of pages
             pages = len(pdf.sequence)
             log.debug("PDF with {} page(s) detected".format(pages))
+            if pages == 0:
+                misperrors["error"] = "PDF has no pages to process."
+                return misperrors
             # Create new image object where the height will be the number of pages. With huge PDFs this will overflow, break, consume silly memory etc…
             img = WImage(width=pdf.width, height=pdf.height * pages)
             # Cycle through pages and stitch it together to one big file


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A zero-page PDF makes the OCR import module die with `UnboundLocalError` instead of a MISP error.

- **Problem** — The PDF-stitching path in `misp_modules/modules/import_mod/ocr.py` logs a summary line referencing the loop variable `p` after the page loop, so a PDF reporting zero pages never binds `p` and the module dies with `UnboundLocalError: local variable 'p' referenced before assignment`.
- **Fix** — Checks for `pages == 0` immediately after the count is computed and returns a `misperrors` error before the loop and the later reference.
- **Effect** — Submitting an empty or malformed PDF to the OCR import module produces a clear MISP error message instead of an unhandled traceback.
<!-- /bluf -->

### The defect

In `misp_modules/modules/import_mod/ocr.py`, the PDF-stitching handler loops over pages and then logs a summary line that references the loop variable `p` outside the loop:

```python
pages = len(pdf.sequence)
log.debug("PDF with {} page(s) detected".format(pages))
# Create new image object where the height will be the number of pages. ...
img = WImage(width=pdf.width, height=pdf.height * pages)
# Cycle through pages and stitch it together to one big file
for p in range(pages):
    log.debug("Stitching page {}".format(p + 1))
    image = img.composite(pdf.sequence[p], top=pdf.height * p, left=0)
# Create a png blob
image = img.make_blob("png")
log.debug("Final image size is {}x{}".format(pdf.width, pdf.height * (p + 1)))
```

When `pages == 0` (a zero-page PDF), the `for` loop body never executes, so `p` is never bound. The subsequent `log.debug(...".format(pdf.width, pdf.height * (p + 1))...)` line then raises `UnboundLocalError: local variable 'p' referenced before assignment`.

### Impact

An analyst who submits a malformed or empty PDF (0 pages) to the OCR import module gets an unhandled `UnboundLocalError` traceback instead of a clean, actionable MISP error message. This is confusing in the UI/API response and provides no guidance on what went wrong with the input.

### The fix

Added an explicit `pages == 0` check immediately after `pages` is computed, returning a clean `misperrors["error"]` before the loop (and before the later `p` reference) is ever reached.

### Verification

- `flake8 misp_modules/modules/import_mod/ocr.py` — clean, no output.
- Full module test suite: `161 passed, 4 skipped, 5 subtests passed in 32.94s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

