### PR TITLE
[critical] fix: [export_mod] sanitize CSV values against formula injection

### DIFF
--- a/misp_modules/modules/export_mod/threatStream_misp_export.py
+++ b/misp_modules/modules/export_mod/threatStream_misp_export.py
@@ -50,6 +50,14 @@ fieldmap = {
 mispattributes = {"input": list(fieldmap.keys())}
 
 
+def sanitize_csv_value(value):
+    """Prefix values that could be interpreted as spreadsheet formulas to prevent CSV injection."""
+    value = str(value)
+    if value.startswith(("=", "+", "-", "@")):
+        value = "'" + value
+    return value
+
+
 def handler(q=False):
     """
     Convert a MISP query into a CSV file matching the ThreatStream Structured Import file format.
@@ -80,17 +88,17 @@ def handler(q=False):
                     for i, indicator in enumerate(indicators):
                         writer.writerow(
                             {
-                                "value": indicator,
+                                "value": sanitize_csv_value(indicator),
                                 "itype": ts_types[i],
-                                "tags": attribute["comment"],
+                                "tags": sanitize_csv_value(attribute["comment"]),
                             }
                         )
                 else:
                     writer.writerow(
                         {
                             "itype": fieldmap[attribute["type"]],
-                            "value": attribute["value"],
-                            "tags": attribute["comment"],
+                            "value": sanitize_csv_value(attribute["value"]),
+                            "tags": sanitize_csv_value(attribute["comment"]),
                         }
                     )
 

--- a/misp_modules/modules/export_mod/threat_connect_export.py
+++ b/misp_modules/modules/export_mod/threat_connect_export.py
@@ -56,6 +56,14 @@ fieldmap = {
 mispattributes = {"input": list(fieldmap.keys())}
 
 
+def sanitize_csv_value(value):
+    """Prefix values that could be interpreted as spreadsheet formulas to prevent CSV injection."""
+    value = str(value)
+    if value.startswith(("=", "+", "-", "@")):
+        value = "'" + value
+    return value
+
+
 def handler(q=False):
     """
     Convert a MISP query into a CSV file matching the ThreatConnect Structured Import file format.
@@ -90,18 +98,18 @@ def handler(q=False):
                         writer.writerow(
                             {
                                 "Type": tc_types[i],
-                                "Value": indicator,
+                                "Value": sanitize_csv_value(indicator),
                                 "Source": config["Default_Source"],
-                                "Description": attribute["comment"],
+                                "Description": sanitize_csv_value(attribute["comment"]),
                             }
                         )
                 else:
                     writer.writerow(
                         {
                             "Type": fieldmap[attribute["type"]],
-                            "Value": attribute["value"],
+                            "Value": sanitize_csv_value(attribute["value"]),
                             "Source": config["Default_Source"],
-                            "Description": attribute["comment"],
+                            "Description": sanitize_csv_value(attribute["comment"]),
                         }
                     )
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Raw MISP values in exported CSVs execute as spreadsheet formulas; both export modules now sanitize.

- **Problem** — `threat_connect_export.py` and `threatStream_misp_export.py` write MISP attribute values, comments and tags straight into CSV cells, so any value beginning with `=`, `+`, `-` or `@` is interpreted as a formula by Excel, Sheets or LibreOffice — the classic formula-injection path, and these values are attacker-influenced via ingested intel and event contributors.
- **Fix** — Adds a `sanitize_csv_value()` helper in each module that prefixes such values with a single quote, applied at all four `writerow` sites.
- **Effect** — Analysts opening these exports no longer risk formula execution in their spreadsheet application.
- **Cost** — Only cells already starting with those four characters change, gaining a leading apostrophe so spreadsheets treat them as text.
<!-- /bluf -->

Both `threat_connect_export.py` and `threatStream_misp_export.py` write MISP attribute values and comments directly into CSV cells with no sanitization:

```python
writer.writerow(
    {
        "Type": fieldmap[attribute["type"]],
        "Value": attribute["value"],
        "Source": config["Default_Source"],
        "Description": attribute["comment"],
    }
)
```

If a MISP attribute value or comment begins with `=`, `+`, `-`, or `@`, the exported CSV cell is interpreted as a formula by Excel, Google Sheets, or LibreOffice Calc when opened. This is the classic CSV/formula-injection pattern: since attribute values and comments are attacker-influenced (e.g. sourced from ingested threat intel or event contributors), an analyst who exports via one of these modules and opens the resulting CSV can have arbitrary spreadsheet formulas execute — including formulas that exfiltrate data or shell out via `DDE`/`WEBSERVICE` style payloads.

### Fix

Added a small `sanitize_csv_value()` helper in each module that prefixes any cell value starting with `=`, `+`, `-`, or `@` with a leading single quote, and applied it to the `Value`/`Description` fields (threat_connect) and `value`/`tags` fields (threatStream) at all four `writerow` sites. This is the standard OWASP-recommended mitigation for CSV/formula injection.

### Behaviour change

Exported cell content changes only for values that already begin with `=`, `+`, `-`, or `@`: those cells now carry a leading single quote so spreadsheet applications treat them as literal text instead of a formula. All other values are unaffected.

### Verification

- `flake8` clean (exit 0) on both changed files.
- Module test suite: `161 passed, 4 skipped, 5 subtests passed in 41.40s`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

