### PR TITLE
[medium] fix: [whoisfreaks] guard parse_domain_reputation against non-dict input

### DIFF
--- a/misp_modules/modules/expansion/whoisfreaks.py
+++ b/misp_modules/modules/expansion/whoisfreaks.py
@@ -335,6 +335,9 @@ def parse_domain_reputation(data, domain):
     attrs = []
     tags = []
 
+    if not isinstance(data, dict):
+        return attrs, tags, None
+
     intelligence = data.get("intelligence") or {}
     for ioc in intelligence.get("related_iocs") or []:
         value = ioc.get("value")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `parse_domain_reputation()` misses the dict guard its siblings have, so odd API payloads crash it.

- **Problem** — `parse_domain_reputation()` in `misp_modules/modules/expansion/whoisfreaks.py` calls `data.get("intelligence")` without checking the argument type, so a WhoisFreaks Domain Reputation API list, string or null error payload raises an unhandled `AttributeError`. The siblings `expand_whois`, `expand_dns` and `parse_ip_whois` already carry an `isinstance(data, dict)` guard and this one was missed.
- **Fix** — Adds the same guard, returning the function's existing `(attrs, tags, None)` contract.
- **Effect** — Analysts enriching a domain get a clean no-reputation-data result rather than a traceback when the upstream API misbehaves.
<!-- /bluf -->

`parse_domain_reputation()` in `whoisfreaks.py` dereferences its `data` argument without checking its type:

```python
def parse_domain_reputation(data, domain):
    """Return (flat_attributes, tags, reputation_object) from a Domain Reputation response."""
    attrs = []
    tags = []

    intelligence = data.get("intelligence") or {}
```

If the WhoisFreaks Domain Reputation API returns something other than a JSON object (an error payload that is a list, a string, or `null`), `data.get(...)` raises `AttributeError`. The three sibling parsers in the same module — `expand_whois`, `expand_dns`, and `parse_ip_whois` — all guard against exactly this with `if not isinstance(data, dict): return ...`, but this function was missed.

**Impact:** an analyst enriching a domain attribute with the WhoisFreaks module hits an unhandled exception instead of a clean "no reputation data" result whenever the upstream API returns a non-dict response for that endpoint.

**Fix:** add the same `isinstance(data, dict)` guard at the top of `parse_domain_reputation()`, returning the function's existing three-tuple contract (`attrs, tags, None`) on failure, matching the style of the three sibling guards.

Found during a review of the repository; other findings are being submitted as separate PRs.

### Verification

- `flake8` clean on `misp_modules/modules/expansion/whoisfreaks.py`.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 30.75s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

