### PR TITLE
[high] fix: [vt_graph_parser] split filename|hash on the last pipe

### DIFF
--- a/misp_modules/lib/vt_graph_parser/helpers/wrappers.py
+++ b/misp_modules/lib/vt_graph_parser/helpers/wrappers.py
@@ -40,7 +40,7 @@ class MispAttribute(object):
             label (str): attribute label.
         """
         if misp_type.startswith("filename|"):
-            label, value = value.split("|")
+            label, value = value.rsplit("|", 1)
             misp_type = "filename|X"
         if misp_type == "filename":
             label = value


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `split("|")` on a `filename|hash` value crashes the whole VirusTotal Graph export.

- **Problem** — `MispAttribute.__init__` in `misp_modules/lib/vt_graph_parser/helpers/wrappers.py` splits a composite `filename|hash` attribute with `value.split("|")` and unpacks the result into two names, so any filename containing a pipe — a legal filename character — yields more than two parts and raises `ValueError: too many values to unpack`, aborting the whole export.
- **Fix** — Changes the call to `value.rsplit("|", 1)` so only the trailing hash token is separated off.
- **Effect** — Exporting an event with such an attribute succeeds instead of failing outright, with no change for filenames without pipes.
<!-- /bluf -->

### The defect

```python
if misp_type.startswith("filename|"):
    label, value = value.split("|")
```

`MispAttribute.__init__` in `misp_modules/lib/vt_graph_parser/helpers/wrappers.py` splits a `filename|hash` MISP attribute value on `|` with no limit. `str.split("|")` on a value like `report|final|v1.exe|44d88612fea8a8f36de82e1278abb02f` returns more than two elements, and unpacking that into `label, value` raises `ValueError: too many values to unpack`, which aborts the entire VT Graph export.

### Impact

Any MISP analyst exporting a `filename|md5`/`filename|sha1`/`filename|sha256` composite attribute to VirusTotal Graph fails outright as soon as the filename itself contains a pipe character (a legal, unremarkable character in a filename). The whole export errors instead of just handling that one attribute.

### The fix

Changed the split to `value.rsplit("|", 1)`, splitting from the right so only the trailing hash token (which never contains `|`) is separated off, regardless of how many `|` characters appear in the filename portion.

No behaviour change for the common case (filenames without `|`); this only fixes the crash for filenames containing `|`.

### Verification

- `py_compile` clean on the changed file (it lives under `misp_modules/lib/`, so flake8's CI exclusions do not apply to it).
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 28.23s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

