### PR TITLE
[high] fix: [cof2misp] fix operator precedence in COF timestamp validation

### DIFF
--- a/misp_modules/lib/cof2misp/cof.py
+++ b/misp_modules/lib/cof2misp/cof.py
@@ -75,7 +75,7 @@ def is_cof_valid_simple(d: dict) -> bool:
     if not isinstance(d["rdata"], str) and not isinstance(d["rdata"], list):
         print("'rdata' is not a list and not a string.", file=sys.stderr)
         return False
-    if not ("time_first" in d and "time_last" in d) or ("zone_time_first" in d and "zone_time_last" in d):
+    if not (("time_first" in d and "time_last" in d) or ("zone_time_first" in d and "zone_time_last" in d)):
         print(
             "We are missing EITHER ('first_seen' and 'last_seen') OR ('zone_time_first' and zone_time_last') fields",
             file=sys.stderr,


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Missing parentheses in `is_cof_valid_simple()` make Python reject valid zone-time COF records.

- **Problem** — `is_cof_valid_simple()` in `misp_modules/lib/cof2misp/cof.py` writes its timestamp check as `not (A) or (B)`, but Python binds `not` tighter than `or`, so the intended `not (A or B)` is never evaluated. Any COF passive DNS record carrying only the documented `zone_time_first`/`zone_time_last` pair is rejected with a misleading missing-required-fields message.
- **Fix** — Adds the parentheses so the two valid-pair checks are combined before negation.
- **Effect** — `cof2misp` imports zone-time records instead of discarding them, so analysts stop losing legitimate passive DNS data on import.
<!-- /bluf -->

### The defect

In `misp_modules/lib/cof2misp/cof.py`, `is_cof_valid_simple()` checked for the presence of a valid timestamp pair like this:

```python
if not ("time_first" in d and "time_last" in d) or ("zone_time_first" in d and "zone_time_last" in d):
```

Due to Python operator precedence, `not` binds tighter than `or`, so this parses as:

```python
(not ("time_first" in d and "time_last" in d)) or ("zone_time_first" in d and "zone_time_last" in d)
```

The intent was "reject the record unless it has EITHER the `time_first`/`time_last` pair OR the `zone_time_first`/`zone_time_last` pair" — i.e. `not (A or B)`. Instead, the expression evaluates to `(not A) or B`, which is true (and so returns `False`, rejecting the record) whenever `A` is false, regardless of `B`. Concretely: a record that has only `zone_time_first`/`zone_time_last` (and lacks `time_first`/`time_last`) makes `A` false, so `not A` is `True`, and the whole condition is `True` — the record is wrongly rejected as missing required fields, even though it actually has a valid timestamp pair.

### Impact

Any COF (Common Output Format) DNS record that carries only the `zone_time_first`/`zone_time_last` fields — a legitimate, documented alternative to `time_first`/`time_last` — is silently dropped by the `cof2misp` conversion before it ever reaches MISP. An analyst importing passive DNS data in this format loses valid records without any indication that they were rejected, other than a generic stderr message that (incorrectly) claims required fields are missing.

### The fix

Add the missing parentheses so the `or` combines the two "has a valid pair" checks before negation, matching the intended `not (A or B)` semantics:

```python
if not (("time_first" in d and "time_last" in d) or ("zone_time_first" in d and "zone_time_last" in d)):
```

No behaviour change beyond correcting this logic error to match the documented/intended validation rule.

### Verification

- `python -m py_compile misp_modules/lib/cof2misp/cof.py` — clean.
- Full module test suite: 161 passed, 4 skipped, 5 subtests passed in 22.08s.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

