### PR TITLE
[critical] fix: [export_mod/yara_export] escape attribute values in generated YARA string/meta literals

### DIFF
--- a/misp_modules/modules/export_mod/yara_export.py
+++ b/misp_modules/modules/export_mod/yara_export.py
@@ -70,17 +70,20 @@ class YaraRule:
         for key, values in self.meta.items():
             i = 0
             if len(values) == 1:
-                result.append(f'        {key} = "{values[0]}"')
+                escaped_value = values[0].replace("\\", "\\\\").replace('"', '\\"')
+                result.append(f'        {key} = "{escaped_value}"')
                 continue
             for value in values:
-                result.append(f'        {key}_{i} = "{value}"')
+                escaped_value = value.replace("\\", "\\\\").replace('"', '\\"')
+                result.append(f'        {key}_{i} = "{escaped_value}"')
                 i += 1
 
         result.append("    strings:")
         for key, values in self.strings.items():
             i = 0
             for value in values:
-                result.append(f'        ${key}_{i} = "{value}"')
+                escaped_value = value.replace("\\", "\\\\").replace('"', '\\"')
+                result.append(f'        ${key}_{i} = "{escaped_value}"')
                 i += 1
 
         result.append("    condition:")
@@ -267,9 +270,15 @@ def handler(q=False):
                     # ignore unsupported types
                     pass
         yara_rules.append(str(yr))
+    ruleset = "\n".join(yara_rules)
+    try:
+        yara.compile(source=ruleset)
+    except Exception:
+        misperrors["error"] = "The generated YARA ruleset does not compile."
+        return misperrors
     r = {
         "response": [],
-        "data": str(base64.b64encode(bytes("\n".join(yara_rules), "utf-8")), "utf-8"),
+        "data": str(base64.b64encode(bytes(ruleset, "utf-8")), "utf-8"),
     }
 
     return r


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `yara_export` splices attribute values into YARA literals unescaped; this escapes and compiles them.

- **Problem** — `YaraRule.__str__` in `misp_modules/modules/export_mod/yara_export.py` interpolates MISP attribute values and meta fields (event info, org name) into double-quoted YARA string literals without escaping backslashes or quotes, so a value containing a double quote breaks out of its literal and attacker-supplied text is spliced into the rule body as YARA syntax; unlike `handle_yara`, this path never validated the result.
- **Fix** — Escapes backslash and double quote at both interpolation sites and compiles the assembled ruleset with `yara.compile()` before returning it.
- **Effect** — Such values stay inert data in exports, and a ruleset that still fails to compile returns a `misperrors` response instead of a silently broken or manipulated rule.
<!-- /bluf -->

`YaraRule.__str__` in `misp_modules/modules/export_mod/yara_export.py` interpolated MISP attribute values and meta values (event info, org name, link attributes) directly into double-quoted YARA string literals without escaping backslash or embedded double-quote characters:

```python
for key, values in self.meta.items():
    ...
    result.append(f'        {key} = "{values[0]}"')
    ...
for key, values in self.strings.items():
    ...
    result.append(f'        ${key}_{i} = "{value}"')
```

Unlike the `handle_yara` path in the same module, the ruleset built by this class was also never passed through `yara.compile()` before being returned.

**Impact:** an attacker-controlled MISP attribute value (or event info / org name) containing a `"` or `\` breaks out of the YARA string literal it was placed in. Depending on the surrounding content this either produces a ruleset that fails to compile in the analyst's YARA engine (an unusable export with no warning from the module) or, more seriously, lets attacker-supplied text be spliced into the rule body as YARA syntax rather than staying inert data — an analyst exporting attributes to a YARA rule has no indication the export is malformed or manipulated until it fails, or misbehaves, downstream.

### Fix
Escape `\` and `"` in both the strings-section and meta-section interpolation sites, and compile the fully generated ruleset with `yara.compile()` before returning it, returning a `misperrors` response instead of silently emitting an invalid/unsafe ruleset if compilation fails.

### Verification
- `flake8` on the changed file: clean, no output.
- `python -m pytest tests/` against a local `misp-modules` instance: `161 passed, 4 skipped, 5 subtests passed`.

Found during a review of the repository; other findings are being submitted as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

