### PR TITLE
Add TweetFeed Lookup expansion/hover module

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ For further Information see the [license file](https://misp.github.io/misp-modul
 * [ThreatMiner Lookup](https://misp.github.io/misp-modules/expansion/#threatminer-lookup) - Module to get information from ThreatMiner.
 * [Triage Submit](https://misp.github.io/misp-modules/expansion/#triage-submit) - Module to submit samples to tria.ge
 * [TruSTAR Enrich](https://misp.github.io/misp-modules/expansion/#trustar-enrich) - Module to get enrich indicators with TruSTAR.
+* [TweetFeed Lookup](https://misp.github.io/misp-modules/expansion/#tweetfeed-lookup) - Look up an IOC in TweetFeed, the CC0 feed of IOCs shared by the infosec community on X/Twitter: reporters, source tweets, hashtags, AI context and campaign membership.
 * [URLhaus Lookup](https://misp.github.io/misp-modules/expansion/#urlhaus-lookup) - Query of the URLhaus API to get additional information about the input attribute.
 * [URLScan Lookup](https://misp.github.io/misp-modules/expansion/#urlscan-lookup) - An expansion module to query urlscan.io.
 * [Validin DNS History](https://misp.github.io/misp-modules/expansion/#validin-dns-history) - Validin internet dataset expansion. Returns dns-records, web crawls, registration (WHOIS) records, and certificates from Validin's historic internet intelligence dataset.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2653,6 +2653,30 @@ Module to get enrich indicators with TruSTAR.
 
 -----
 
+#### [TweetFeed Lookup](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/tweetfeed.py)
+
+Look up an IOC in TweetFeed (tweetfeed.live), the free CC0 feed of URLs, domains, IPs and hashes shared by the infosec community on X/Twitter: who reported it and when, the source tweets and hashtags, cross-feed corroboration, AI-generated context and campaign membership.
+[[source code](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/tweetfeed.py)]
+
+- **features**:
+>The module takes an IP, domain, hostname, URL, MD5 or SHA-256 attribute and queries the TweetFeed API for it. Matches come back as microblog objects for the source tweets (reporter, hashtags, first/last seen), plus attributes for co-reported IOCs, AI-generated context, domain registration and hosting, IP network metadata, corroboration from other feeds and campaign membership. Everything returned is community reported and unverified: no MISP tag or confidence score is set from it. The live 365-day window is queried first, and IOCs older than that are looked up in TweetFeed's separate archive.
+
+- **input**:
+>An IP address, domain, hostname, URL, MD5 or SHA-256 attribute.
+
+- **output**:
+>microblog objects for the source tweets, domain-ip / text / link attributes with registration, network, corroboration, AI context and campaign data.
+
+- **references**:
+> - https://tweetfeed.live
+> - https://tweetfeed.live/api/
+> - https://tweetfeed.live/hunt/
+
+- **requirements**:
+>No API key required.
+
+-----
+
 #### [URLhaus Lookup](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/urlhaus.py)
 
 <img src=logos/urlhaus.png height=60>

--- a/documentation/mkdocs/expansion.md
+++ b/documentation/mkdocs/expansion.md
@@ -2932,6 +2932,30 @@ Module to get enrich indicators with TruSTAR.
 
 -----
 
+#### [TweetFeed Lookup](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/tweetfeed.py)
+
+Look up an IOC in TweetFeed (tweetfeed.live), the free CC0 feed of URLs, domains, IPs and hashes shared by the infosec community on X/Twitter: who reported it and when, the source tweets and hashtags, cross-feed corroboration, AI-generated context and campaign membership.
+[[source code](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/tweetfeed.py)]
+
+- **features**:
+>The module takes an IP, domain, hostname, URL, MD5 or SHA-256 attribute and queries the TweetFeed API for it. Matches come back as microblog objects for the source tweets (reporter, hashtags, first/last seen), plus attributes for co-reported IOCs, AI-generated context, domain registration and hosting, IP network metadata, corroboration from other feeds and campaign membership. Everything returned is community reported and unverified: no MISP tag or confidence score is set from it. The live 365-day window is queried first, and IOCs older than that are looked up in TweetFeed's separate archive.
+
+- **input**:
+>An IP address, domain, hostname, URL, MD5 or SHA-256 attribute.
+
+- **output**:
+>microblog objects for the source tweets, domain-ip / text / link attributes with registration, network, corroboration, AI context and campaign data.
+
+- **references**:
+> - https://tweetfeed.live
+> - https://tweetfeed.live/api/
+> - https://tweetfeed.live/hunt/
+
+- **requirements**:
+>No API key required.
+
+-----
+
 #### [URLhaus Lookup](https://github.com/MISP/misp-modules/tree/main/misp_modules/modules/expansion/urlhaus.py)
 
 <img src=../logos/urlhaus.png height=60>

--- a/misp_modules/modules/expansion/tweetfeed.py
+++ b/misp_modules/modules/expansion/tweetfeed.py
@@ -1,0 +1,337 @@
+"""TweetFeed Lookup expansion/hover module.
+
+Queries the TweetFeed (tweetfeed.live) public API for IOCs (URLs, domains,
+IPs, MD5/SHA256 hashes) reported by the infosec community on X/Twitter. The
+API is queried with the attribute value unchanged (only whitespace-stripped);
+TweetFeed normalises the value itself (defang, scheme, case). Every field
+returned by the API other than found/query/window/records is optional, so
+every access below goes through .get() defensively.
+
+Mapping to MISP:
+  - each TweetFeed "record" (one report of the queried value, extracted from
+    a tweet) becomes a `microblog` object per underlying tweet URL. Tweet
+    URLs are deduplicated: several records can point to the same tweet when
+    it mentioned the value in more than one form (e.g. as both a domain and
+    a URL);
+  - IOCs "related" to the queried value (co-reported in the same tweet)
+    become MISP attributes, referenced with "mentions" from the microblog
+    object(s) they were extracted from;
+  - the "ai" block becomes a single free-text attribute holding the
+    LLM-generated summary. It is unverified, community-authored analysis: no
+    MISP tag and no confidence score are asserted from it;
+  - "reg" (domain registration/hosting) becomes a `domain-ip` object;
+  - "net" (IP network metadata) becomes a free-text attribute;
+  - "external" (corroboration from ThreatFox/URLhaus/...) becomes a link (or
+    text) attribute per source;
+  - "campaigns" (TweetFeed's own clustering) becomes a link attribute per
+    campaign;
+  - "archive" records (older than the 365-day live window) become
+    `microblog` objects without a resolvable username, since the archive
+    only keeps a synthetic status URL built from the tweet id.
+
+No confidence score, TLP or MISP tag is ever asserted: everything TweetFeed
+reports is community-submitted and not independently verified.
+"""
+import json
+import re
+
+import requests
+from pymisp import MISPAttribute, MISPEvent, MISPObject
+
+from . import check_input_attribute, standard_error_message
+
+misperrors = {"error": "Error"}
+
+mispattributes = {
+    "input": ["ip-src", "ip-dst", "domain", "hostname", "url", "md5", "sha256"],
+    "format": "misp_standard",
+}
+
+moduleinfo = {
+    "version": "1",
+    "author": "Daniel López",
+    "description": (
+        "Look up an IOC in TweetFeed (tweetfeed.live), the free CC0 feed of URLs, domains, IPs and hashes shared by"
+        " the infosec community on X/Twitter: who reported it and when, the source tweets and hashtags, cross-feed"
+        " corroboration, AI-generated context and campaign membership."
+    ),
+    "module-type": ["expansion", "hover"],
+    "name": "TweetFeed Lookup",
+    "requirements": ["No API key required."],
+    "features": (
+        "The module takes an IP, domain, hostname, URL, MD5 or SHA-256 attribute and queries the TweetFeed API for"
+        " it. Matches come back as microblog objects for the source tweets (reporter, hashtags, first/last seen),"
+        " plus attributes for co-reported IOCs, AI-generated context, domain registration and hosting, IP network"
+        " metadata, corroboration from other feeds and campaign membership. Everything returned is community"
+        " reported and unverified: no MISP tag or confidence score is set from it. The live 365-day window is"
+        " queried first, and IOCs older than that are looked up in TweetFeed's separate archive."
+    ),
+    "references": ["https://tweetfeed.live", "https://tweetfeed.live/api/", "https://tweetfeed.live/hunt/"],
+    "input": "An IP address, domain, hostname, URL, MD5 or SHA-256 attribute.",
+    "output": (
+        "microblog objects for the source tweets, domain-ip / text / link attributes with registration, network,"
+        " corroboration, AI context and campaign data."
+    ),
+}
+moduleconfig = []
+
+API_URL = "https://api.tweetfeed.live/v1/ioc"
+USER_AGENT = "misp-modules tweetfeed-expansion/1"
+TIMEOUT = 15
+
+_TWEET_URL_RE = re.compile(r"^https?://(?:www\.)?(?:x|twitter)\.com/([^/]+)/status/\d+", re.IGNORECASE)
+
+_RELATED_TYPE_MAP = {"url": "url", "domain": "domain", "ip": "ip-dst", "sha256": "sha256", "md5": "md5"}
+
+_EXTERNAL_SOURCE_NAMES = {
+    "threatfox": "ThreatFox",
+    "urlhaus": "URLhaus",
+    "malwarebazaar": "MalwareBazaar",
+    "usom": "USOM",
+    "ipsum": "IPsum",
+}
+
+
+def _extract_username(tweet_url):
+    match = _TWEET_URL_RE.match(tweet_url or "")
+    return match.group(1) if match else None
+
+
+def _new_microblog(uuid, tweet_url, username, tags, creation_date, comment):
+    obj = MISPObject("microblog")
+    obj.comment = comment
+    obj.add_attribute("type", type="text", value="Twitter")
+    obj.add_attribute("url", type="url", value=tweet_url)
+    if username:
+        obj.add_attribute("username", type="text", value=username)
+    for tag in tags:
+        obj.add_attribute("hashtag", type="text", value=tag)
+    if creation_date:
+        obj.add_attribute("creation-date", type="datetime", value=creation_date)
+    if uuid:
+        obj.add_reference(uuid, "mentions")
+    return obj
+
+
+def _add_records(misp_event, uuid, value, records):
+    """Create microblog objects for each unique tweet, and attributes for the co-reported IOCs."""
+    seen_tweets = set()
+    record_objects = []
+    for record in records:
+        tweets = record.get("tweets") or []
+        objs = []
+        for tweet_url in tweets:
+            if not tweet_url or tweet_url in seen_tweets:
+                continue
+            seen_tweets.add(tweet_url)
+            creation_date = record.get("first_seen") if len(tweets) == 1 else None
+            comment = (
+                f"TweetFeed: {record.get('count')} report(s) of {record.get('value')}, first seen"
+                f" {record.get('first_seen')}, last seen {record.get('last_seen')}"
+            )
+            objs.append(
+                _new_microblog(
+                    uuid, tweet_url, _extract_username(tweet_url), record.get("tags") or [], creation_date, comment
+                )
+            )
+        if objs:
+            record_objects.append((record, objs))
+
+    related_uuids = {}
+    for record, objs in record_objects:
+        for related in record.get("related") or []:
+            if not isinstance(related, (list, tuple)) or len(related) != 2:
+                continue
+            related_type, related_value = related
+            if related_value == value:
+                continue
+            mapped_type = _RELATED_TYPE_MAP.get(related_type)
+            if not mapped_type:
+                continue
+            key = (mapped_type, related_value)
+            if key not in related_uuids:
+                attribute = MISPAttribute()
+                attribute.from_dict(
+                    type=mapped_type,
+                    value=related_value,
+                    to_ids=False,
+                    comment=f"Co-reported with {value} in the same tweet (TweetFeed)",
+                )
+                misp_event.add_attribute(**attribute)
+                related_uuids[key] = attribute.uuid
+            for obj in objs:
+                obj.add_reference(related_uuids[key], "mentions")
+
+    for _, objs in record_objects:
+        for obj in objs:
+            misp_event.add_object(obj)
+
+
+def _add_ai(misp_event, ai):
+    summary = ai.get("summary")
+    if not summary:
+        return
+    value = summary
+    if ai.get("threat_type"):
+        value += f" | threat_type: {ai['threat_type']}"
+    if ai.get("family"):
+        value += f" | family: {ai['family']}"
+    misp_event.add_attribute(
+        type="text",
+        value=value,
+        comment="TweetFeed AI enrichment: LLM-generated from the source tweet, unverified",
+        disable_correlation=True,
+    )
+
+
+def _add_reg(misp_event, uuid, reg):
+    apex = reg.get("apex")
+    if not apex:
+        return
+    obj = MISPObject("domain-ip")
+    obj.add_attribute("domain", type="domain", value=apex)
+    for ip in reg.get("ips") or []:
+        obj.add_attribute("ip", type="ip-dst", value=ip, to_ids=False)
+    if reg.get("created"):
+        obj.add_attribute("registration-date", type="datetime", value=reg["created"])
+    parts = []
+    if reg.get("registrar"):
+        parts.append(f"registrar: {reg['registrar']}")
+    if reg.get("ns"):
+        parts.append(f"NS: {', '.join(reg['ns'])}")
+    if reg.get("asn") or reg.get("org"):
+        parts.append(f"{reg.get('asn') or ''} {reg.get('org') or ''}".strip())
+    if reg.get("age_days_at_report") is not None:
+        age_text = f"{reg['age_days_at_report']} days old when first reported"
+        if reg.get("newly_registered"):
+            age_text += " (newly registered)"
+        parts.append(age_text)
+    if parts:
+        obj.add_attribute("text", type="text", value=" | ".join(parts))
+    if uuid:
+        obj.add_reference(uuid, "related-to")
+    misp_event.add_object(obj)
+
+
+def _add_net(misp_event, net):
+    parts = []
+    if net.get("org"):
+        asn = f" ({net['asn']})" if net.get("asn") else ""
+        parts.append(f"{net['org']}{asn}")
+    for key in ("city", "country"):
+        if net.get(key):
+            parts.append(net[key])
+    if not parts:
+        return
+    value = "Network: " + ", ".join(parts)
+    if net.get("fetched_at"):
+        value += f" - as of {net['fetched_at']}"
+    misp_event.add_attribute(type="text", value=value, comment="TweetFeed IP metadata", disable_correlation=True)
+
+
+def _add_external(misp_event, external_entries):
+    for entry in external_entries or []:
+        name = _EXTERNAL_SOURCE_NAMES.get(entry.get("src"), entry.get("src"))
+        sentence = f"Also listed in {name}: {entry.get('threat')} (added {entry.get('added')})"
+        if entry.get("link"):
+            misp_event.add_attribute(type="link", value=entry["link"], comment=sentence, disable_correlation=True)
+        else:
+            misp_event.add_attribute(type="text", value=sentence, disable_correlation=True)
+
+
+def _add_campaigns(misp_event, campaigns):
+    for campaign in campaigns or []:
+        campaign_id = campaign.get("id")
+        if not campaign_id:
+            continue
+        value = f"https://tweetfeed.live/campaigns/#{campaign_id}"
+        comment = (
+            f"TweetFeed campaign '{campaign.get('name')}' ({campaign.get('ioc_count')} IOCs, confidence"
+            f" {campaign.get('confidence')}, last seen {campaign.get('last_seen')}); export:"
+            f" https://api.tweetfeed.live/v1/campaigns/{campaign_id}"
+        )
+        misp_event.add_attribute(type="link", value=value, comment=comment, disable_correlation=True)
+
+
+def _add_archive(misp_event, uuid, archive):
+    for record in archive.get("records") or []:
+        tweet_id = record.get("tweet_id")
+        if not tweet_id:
+            continue
+        comment = (
+            f"TweetFeed archive (older than 365 days): {record.get('count')} report(s), first seen"
+            f" {record.get('first_seen')}, last seen {record.get('last_seen')}"
+        )
+        obj = MISPObject("microblog")
+        obj.comment = comment
+        obj.add_attribute("type", type="text", value="Twitter")
+        obj.add_attribute("url", type="url", value=f"https://x.com/i/web/status/{tweet_id}")
+        for tag in record.get("tags") or []:
+            obj.add_attribute("hashtag", type="text", value=tag)
+        if record.get("first_seen"):
+            obj.add_attribute("creation-date", type="datetime", value=record["first_seen"])
+        if uuid:
+            obj.add_reference(uuid, "mentions")
+        misp_event.add_object(obj)
+
+
+def handler(q=False):
+    if q is False:
+        return False
+    request = json.loads(q)
+    if not request.get("attribute") or not check_input_attribute(request["attribute"]):
+        return {"error": f"{standard_error_message}, which should contain at least a type, a value and an uuid."}
+
+    attribute = request["attribute"]
+    if attribute.get("type") not in mispattributes["input"]:
+        return {"error": "Unsupported attribute type."}
+
+    value = str(attribute["value"]).strip()
+    uuid = attribute.get("uuid")
+
+    try:
+        response = requests.get(API_URL, params={"value": value}, headers={"User-Agent": USER_AGENT}, timeout=TIMEOUT)
+    except requests.exceptions.RequestException as request_error:
+        return {"error": f"TweetFeed API request failed: {request_error}"}
+
+    if response.status_code != 200:
+        return {"error": f"TweetFeed API returned HTTP {response.status_code}"}
+
+    try:
+        data = response.json()
+    except ValueError:
+        return {"error": "TweetFeed API returned an invalid JSON response."}
+
+    records = data.get("records") or []
+    archive = data.get("archive") or {}
+    archive_records = archive.get("records") or []
+    if not data.get("found") and not records and not archive_records:
+        return {"error": "No IOC report found on TweetFeed for this value."}
+
+    misp_event = MISPEvent()
+    _add_records(misp_event, uuid, value, records)
+    if data.get("ai"):
+        _add_ai(misp_event, data["ai"])
+    if data.get("reg"):
+        _add_reg(misp_event, uuid, data["reg"])
+    if data.get("net"):
+        _add_net(misp_event, data["net"])
+    if data.get("external"):
+        _add_external(misp_event, data["external"])
+    if data.get("campaigns"):
+        _add_campaigns(misp_event, data["campaigns"])
+    if archive_records:
+        _add_archive(misp_event, uuid, archive)
+
+    event = json.loads(misp_event.to_json())
+    results = {key: event[key] for key in ("Attribute", "Object") if event.get(key)}
+    return {"results": results}
+
+
+def introspection():
+    return mispattributes
+
+
+def version():
+    moduleinfo["config"] = moduleconfig
+    return moduleinfo

--- a/tests/test_tweetfeed.py
+++ b/tests/test_tweetfeed.py
@@ -1,0 +1,190 @@
+import json
+from unittest.mock import patch
+
+import requests
+
+from misp_modules.modules.expansion import tweetfeed
+
+# Fixtures below are the verbatim JSON bodies captured from
+# https://api.tweetfeed.live/v1/ioc?value=<v> on 2026-09-06.
+
+IOC_DOMAIN = json.loads(
+    r"""{"found":true,"query":"raku-point-gche.com","window":"365d","records":[{"count":1,"first_seen":"2026-09-05 23:09:02","last_seen":"2026-09-05 23:09:02","related":[["domain","raku-point-ankanz.com"],["domain","raku-point-edia.com"],["sha256","4d7e9e75f44a68fd6c109bbfa6d6b8fd343b274e7ac1afb0a0a628f624a83308"]],"tags":["#malware","#phishing"],"tweets":["https://x.com/masaomi346/status/2096375079101940086"],"type":"domain","users":["masaomi346"],"value":"raku-point-gche.com"},{"count":1,"first_seen":"2026-09-05 23:09:02","last_seen":"2026-09-05 23:09:02","related":[["domain","raku-point-ankanz.com"],["domain","raku-point-edia.com"],["sha256","4d7e9e75f44a68fd6c109bbfa6d6b8fd343b274e7ac1afb0a0a628f624a83308"]],"tags":["#malware","#phishing"],"tweets":["https://x.com/masaomi346/status/2096375079101940086"],"type":"url","users":["masaomi346"],"value":"https://raku-point-gche.com"}],"ai":{"summary":"Android malware impersonating Rakuten distributed via three phishing domains including raku-point-ankanz.com.","family":null,"threat_type":"malware","suggested_tags":["android","phishing","malware"],"confidence":0.85,"tweet_id":"2096375079101940086","enriched_at":"2026-09-06T00:40:04Z"},"reg":{"apex":"raku-point-gche.com","asn":"AS396982","checked_at":"2026-09-05T23:15:29Z","created":"2026-09-05T20:05:42Z","ips":["34.97.12.225"],"ns":["LOU.NS.CLOUDFLARE.COM","LUCY.NS.CLOUDFLARE.COM"],"org":"Google LLC","registrar":"Aceville Pte. Ltd.","status":"ok","age_days_at_report":0,"newly_registered":true},"campaigns":[{"id":"tfc-09c2d5ccfa23","name":"Android malware impersonating Rakuten on raku-point-* domains","confidence":"low","threat_types":["malware"],"ioc_count":6,"last_seen":"2026-09-05"}]}"""  # noqa: E501
+)
+
+IOC_URL = json.loads(
+    r"""{"found":true,"query":"site-oficial-havan.online","window":"365d","records":[{"count":1,"first_seen":"2026-08-31 00:53:10","last_seen":"2026-08-31 00:53:10","tags":["#phishing","#scam"],"tweets":["https://x.com/Coolcarlos17/status/2094226959345610845"],"type":"domain","users":["Coolcarlos17"],"value":"site-oficial-havan.online"},{"count":1,"first_seen":"2026-08-31 00:53:10","last_seen":"2026-08-31 00:53:10","tags":["#phishing","#scam"],"tweets":["https://x.com/Coolcarlos17/status/2094226959345610845"],"type":"url","users":["Coolcarlos17"],"value":"https://site-oficial-havan.online"}],"ai":{"summary":"Fake clone website impersonating Brazilian retailer Havan (site-oficial-havan.online) used for phishing/scam.","family":null,"threat_type":"phishing","suggested_tags":["phishing","scam"],"confidence":0.88,"tweet_id":"2094226959345610845","enriched_at":"2026-08-31T06:40:05Z"},"reg":{"apex":"site-oficial-havan.online","asn":"AS35278","checked_at":"2026-08-31T01:15:26Z","created":"2026-08-30T22:57:17.584Z","ips":["141.8.192.178"],"ns":["ns1.sprinthost.ru","ns2.sprinthost.ru","ns3.sprinthost.net","ns4.sprinthost.net"],"org":"SPRINTHOST.RU LLC","registrar":"Dynadot Inc","status":"ok","age_days_at_report":1,"newly_registered":true}}"""  # noqa: E501
+)
+
+IOC_IP = json.loads(
+    r"""{"found":true,"query":"43.165.128.22","window":"365d","records":[{"count":3,"first_seen":"2026-08-10 12:48:25","last_seen":"2026-08-31 06:37:28","related":[["url","https://rnwm.pvvchxh.cn/ap/"],["domain","apple.wgxdijj.cn"],["domain","rnwm.fuofxwh.cn"],["url","https://rnwm.fuofxwh.cn/ap/"]],"tags":["#phishing"],"tweets":["https://x.com/Metemcyber/status/2086796811432558627","https://x.com/Metemcyber/status/2089321601628328237","https://x.com/Metemcyber/status/2094313604724212181"],"type":"url","users":["Metemcyber"],"value":"http://43.165.128.22"},{"count":3,"first_seen":"2026-08-10 12:48:25","last_seen":"2026-08-31 06:37:28","related":[["url","https://rnwm.pvvchxh.cn/ap/"],["domain","apple.wgxdijj.cn"],["domain","rnwm.fuofxwh.cn"],["url","https://rnwm.fuofxwh.cn/ap/"]],"tags":["#phishing"],"tweets":["https://x.com/Metemcyber/status/2086796811432558627","https://x.com/Metemcyber/status/2089321601628328237","https://x.com/Metemcyber/status/2094313604724212181"],"type":"ip","users":["Metemcyber"],"value":"43.165.128.22"}],"ai":{"summary":"Amazon-branded phishing campaign (Japanese targets) served from rnwm.fuofxwh.cn/ap/ resolving to 43.165.128.22.","family":null,"threat_type":"phishing","suggested_tags":["phishing"],"confidence":0.92,"tweet_id":"2086796811432558627","enriched_at":"2026-08-10T18:40:03Z"},"net":{"city":"Tokyo","country":"JP","fetched_at":"2026-08-10T13:35:03Z","org":"AS132203 Tencent Building, Kejizhongyi Avenue"}}"""  # noqa: E501
+)
+
+IOC_SHA256 = json.loads(
+    r"""{"found":true,"query":"fb86366bffbc63e8b355fd9d1ebef9ab280ffe628b059bea378d28845d8374a5","window":"365d","records":[{"count":1,"first_seen":"2026-09-01 00:31:39","last_seen":"2026-09-01 00:31:39","related":[["domain","point-plsidaw.com"]],"tags":["#malware","#phishing"],"tweets":["https://x.com/masaomi346/status/2094583933044392305"],"type":"sha256","users":["masaomi346"],"value":"fb86366bffbc63e8b355fd9d1ebef9ab280ffe628b059bea378d28845d8374a5"}],"ai":{"summary":"Android malware impersonating the Rakuten Points app distributed via point-plsidaw.com; SHA256 hash provided.","family":null,"threat_type":"malware","suggested_tags":["android","malware","phishing"],"confidence":0.85,"tweet_id":"2094583933044392305","enriched_at":"2026-09-01T06:40:04Z"}}"""  # noqa: E501
+)
+
+IOC_MD5 = json.loads(
+    r"""{"found":true,"query":"3d0a14d2446efc7cde12984611ec6183","window":"365d","records":[{"count":1,"first_seen":"2026-09-02 00:33:42","last_seen":"2026-09-02 00:33:42","related":[["domain","satinmaple4.com"],["url","https://satinmaple4.com/curl/0djk1usgn/yrdkr6r6fyp8viva.txt"],["domain","terminalbrewmac.com"]],"tags":["#ClickFix"],"tweets":["https://x.com/sicehice/status/2094946837140549785"],"type":"md5","users":["sicehice"],"value":"3d0a14d2446efc7cde12984611ec6183"}],"ai":{"summary":"Malicious Google ad impersonating Mac Homebrew delivers ClickFix-style malware via terminalbrewmac.com; payload hosted on satinmaple4.com.","family":null,"threat_type":"malware","suggested_tags":["clickfix","malvertising","malware"],"confidence":0.92,"tweet_id":"2094946837140549785","enriched_at":"2026-09-02T06:40:04Z"}}"""  # noqa: E501
+)
+
+IOC_EXTERNAL = json.loads(
+    r"""{"found":true,"query":"0028.duckdns.org","window":"365d","records":[{"count":1,"first_seen":"2026-02-14 22:37:19","last_seen":"2026-02-14 22:37:19","related":[["domain","forwebsite.ddns.net"],["domain","luvxcide.duckdns.org"],["domain","skibidi111.airdns.org"],["domain","cloud.airdns.org"],["domain","kocrap.airdns.org"]],"tags":[],"tweets":["https://x.com/skocherhan/status/2022802361434222752"],"type":"domain","users":["skocherhan"],"value":"0028.duckdns.org"},{"count":1,"first_seen":"2026-02-14 22:37:19","last_seen":"2026-02-14 22:37:19","related":[["domain","forwebsite.ddns.net"],["domain","luvxcide.duckdns.org"],["domain","skibidi111.airdns.org"],["domain","cloud.airdns.org"],["domain","kocrap.airdns.org"]],"tags":[],"tweets":["https://x.com/skocherhan/status/2022802361434222752"],"type":"url","users":["skocherhan"],"value":"http://0028.duckdns.org"}],"external":[{"added":"2025-12-23","link":"https://threatfox.abuse.ch/ioc/1685203/","src":"threatfox","threat":"botnet_cc (Remcos)"}]}"""  # noqa: E501
+)
+
+IOC_ARCHIVE = json.loads(
+    r"""{"found":false,"query":"103.167.89.81","window":"365d","records":[],"archive":{"window":"pre-365d","total":2,"records":[{"type":"ip","value":"103.167.89.81","first_seen":"2025-05-02 22:48:51","last_seen":"2025-05-07 20:53:55","count":2,"tweet_id":"1918437559014687218","tags":["#C2","#CobaltStrike"]}]}}"""  # noqa: E501
+)
+
+IOC_MISS = json.loads(r"""{"found":false,"query":"google.com","window":"365d","records":[]}""")
+
+
+class MockResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+
+def _query(attr_type="domain", value="raku-point-gche.com", uuid="5b582d80-7a7e-4b6a-9f22-77656e72bb3b"):
+    # uuid="" keeps the required "uuid" key present (satisfies check_input_attribute) while being
+    # falsy, mirroring a hover call that carries no usable reference uuid.
+    attribute = {"type": attr_type, "value": value, "uuid": uuid}
+    return {"module": "tweetfeed", "attribute": attribute}
+
+
+def _handle(payload, attr_type="domain", value="raku-point-gche.com", uuid="5b582d80-7a7e-4b6a-9f22-77656e72bb3b"):
+    with patch.object(tweetfeed.requests, "get", return_value=MockResponse(payload)):
+        return tweetfeed.handler(json.dumps(_query(attr_type, value, uuid)))
+
+
+def test_domain_hit_returns_microblog_related_reg_ai_and_campaign():
+    result = _handle(IOC_DOMAIN)
+    objects = result["results"]["Object"]
+    attributes = result["results"]["Attribute"]
+
+    microblogs = [o for o in objects if o["name"] == "microblog"]
+    assert len(microblogs) == 1
+    mb_values = {a["object_relation"]: a["value"] for a in microblogs[0]["Attribute"]}
+    assert mb_values["username"] == "masaomi346"
+    assert "creation-date" in mb_values
+    hashtags = [a["value"] for a in microblogs[0]["Attribute"] if a["object_relation"] == "hashtag"]
+    assert len(hashtags) == 2
+
+    # Related IOCs co-reported in the same tweet: 2 domains + 1 sha256 (all 3 pairs from the
+    # record's "related" list are distinct and none equals the queried value).
+    related_values = {"raku-point-ankanz.com", "raku-point-edia.com"}
+    related_attrs = [a for a in attributes if a["value"] in related_values or a["type"] == "sha256"]
+    assert len(related_attrs) == 3
+    # 3 references to the related IOCs plus 1 to the queried attribute itself.
+    assert all(ref["relationship_type"] == "mentions" for ref in microblogs[0]["ObjectReference"])
+    assert len(microblogs[0]["ObjectReference"]) == 4
+
+    domain_ip = next(o for o in objects if o["name"] == "domain-ip")
+    di_values = {a["object_relation"]: a["value"] for a in domain_ip["Attribute"]}
+    assert di_values["domain"] == "raku-point-gche.com"
+    assert "registration-date" in di_values
+
+    ai_attrs = [a for a in attributes if a["type"] == "text" and "threat_type: malware" in a["value"]]
+    assert len(ai_attrs) == 1
+
+    campaign_attrs = [a for a in attributes if a["type"] == "link" and "tfc-09c2d5ccfa23" in a["value"]]
+    assert len(campaign_attrs) == 1
+
+
+def test_url_hit_returns_microblog_and_reg_without_campaigns():
+    result = _handle(IOC_URL, attr_type="url", value="https://site-oficial-havan.online")
+    objects = result["results"]["Object"]
+    microblogs = [o for o in objects if o["name"] == "microblog"]
+    assert len(microblogs) == 1
+    domain_ip = next(o for o in objects if o["name"] == "domain-ip")
+    assert {a["object_relation"]: a["value"] for a in domain_ip["Attribute"]}["domain"] == "site-oficial-havan.online"
+    attributes = result["results"].get("Attribute", [])
+    assert not any(a["type"] == "link" and "campaigns" in a["value"] for a in attributes)
+
+
+def test_ip_hit_returns_network_text_attribute():
+    result = _handle(IOC_IP, attr_type="ip-dst", value="43.165.128.22")
+    attributes = result["results"]["Attribute"]
+    net_attrs = [a for a in attributes if a["value"].startswith("Network:")]
+    assert len(net_attrs) == 1
+    objects = result["results"]["Object"]
+    microblogs = [o for o in objects if o["name"] == "microblog"]
+    assert len(microblogs) == 3
+
+
+def test_sha256_and_md5_hits_return_microblog_and_ai_only():
+    for payload, attr_type, value in (
+        (IOC_SHA256, "sha256", "fb86366bffbc63e8b355fd9d1ebef9ab280ffe628b059bea378d28845d8374a5"),
+        (IOC_MD5, "md5", "3d0a14d2446efc7cde12984611ec6183"),
+    ):
+        result = _handle(payload, attr_type=attr_type, value=value)
+        objects = result["results"]["Object"]
+        assert len(objects) == 1
+        assert objects[0]["name"] == "microblog"
+
+
+def test_external_hit_returns_link_with_source_name():
+    result = _handle(IOC_EXTERNAL, attr_type="domain", value="0028.duckdns.org")
+    attributes = result["results"]["Attribute"]
+    links = [a for a in attributes if a["type"] == "link"]
+    assert len(links) == 1
+    assert "ThreatFox" in links[0]["comment"]
+
+
+def test_archive_only_hit_returns_one_microblog_without_username_and_no_error():
+    result = _handle(IOC_ARCHIVE, attr_type="ip-dst", value="103.167.89.81")
+    assert "error" not in result
+    objects = result["results"]["Object"]
+    microblogs = [o for o in objects if o["name"] == "microblog"]
+    assert len(microblogs) == 1
+    values = {a["object_relation"]: a["value"] for a in microblogs[0]["Attribute"]}
+    assert "i/web/status/1918437559014687218" in values["url"]
+    assert "username" not in values
+
+
+def test_miss_returns_no_result_error():
+    result = _handle(IOC_MISS, attr_type="domain", value="google.com")
+    assert "error" in result
+    assert "results" not in result
+
+
+def test_unsupported_attribute_type_returns_error():
+    result = tweetfeed.handler(json.dumps(_query(attr_type="email", value="a@b.com")))
+    assert result["error"] == "Unsupported attribute type."
+
+
+def test_missing_attribute_returns_error():
+    result = tweetfeed.handler(json.dumps({"module": "tweetfeed"}))
+    assert result["error"].startswith('This module requires an "attribute" field')
+
+
+def test_http_error_mentions_status_code():
+    with patch.object(tweetfeed.requests, "get", return_value=MockResponse(None, 500)):
+        result = tweetfeed.handler(json.dumps(_query()))
+    assert "500" in result["error"]
+
+
+def test_requests_exception_is_reported():
+    with patch.object(tweetfeed.requests, "get", side_effect=requests.exceptions.RequestException("boom")):
+        result = tweetfeed.handler(json.dumps(_query()))
+    assert "TweetFeed API request failed" in result["error"]
+
+
+def test_hover_call_without_uuid_does_not_crash():
+    # No reference to the (missing) queried-attribute uuid; the 3 related-IOC references
+    # (which don't depend on it) are still present.
+    result = _handle(IOC_DOMAIN, uuid="")
+    objects = result["results"]["Object"]
+    microblogs = [o for o in objects if o["name"] == "microblog"]
+    assert len(microblogs) == 1
+    referenced_uuids = [ref["referenced_uuid"] for ref in microblogs[0].get("ObjectReference", [])]
+    assert "" not in referenced_uuids
+    assert len(referenced_uuids) == 3
+
+
+def test_introspection_and_version():
+    assert tweetfeed.introspection() == tweetfeed.mispattributes
+    assert tweetfeed.version()["name"] == "TweetFeed Lookup"


### PR DESCRIPTION
## What

New `expansion` + `hover` module **TweetFeed Lookup** (`misp_modules/modules/expansion/tweetfeed.py`).

[TweetFeed](https://tweetfeed.live) is a free, CC0 feed of URLs, domains, IPs and MD5/SHA-256 hashes that security researchers share on X/Twitter, extracted every 15 minutes since 2021. MISP already consumes it as a bulk feed; this module adds the per-attribute half: given an `ip-src`, `ip-dst`, `domain`, `hostname`, `url`, `md5` or `sha256` attribute it calls `GET https://api.tweetfeed.live/v1/ioc?value=<v>` (no API key, 365-day window plus an older archive) and returns `misp_standard` results.

## Mapping

- each source tweet -> a `microblog` object (`type` Twitter, `url`, `username` parsed from the tweet URL, one `hashtag` per tag, `creation-date` when unambiguous), referenced to the queried attribute with `mentions`;
- IOCs co-reported in the same tweet -> attributes (`to_ids` false) referenced from the microblog object with `mentions`;
- domain registration / hosting (`reg`) -> a `domain-ip` object (apex, IPs, `registration-date`, registrar / NS / ASN / age in `text`);
- IP network metadata, cross-feed corroboration (URLhaus, ThreatFox, MalwareBazaar, USOM, IPsum), AI-generated context and campaign membership -> `text` / `link` attributes with `disable_correlation`;
- reports older than 365 days -> `microblog` objects built from the archived tweet id.

Deliberately **no tag and no confidence score** are set from this data: it is community reported and not independently verified. The AI summary is labelled as LLM-generated in the attribute comment.

## Tests and docs

- `tests/test_tweetfeed.py`: 13 pytest cases that mock `requests.get` with verbatim captures of the live API (domain, url, ip, sha256, md5, corroborated, archive-only, miss, error paths, hover call without uuid, introspection/version). Same style as `tests/test_xposedornot.py`.
- `flake8` clean at the project's 120-column limit.
- `README.md` bullet and the `documentation/README.md` / `documentation/mkdocs/expansion.md` blocks were added by hand following the generator layout; happy to regenerate if you prefer.

## Note for reviewers

While writing the tests I found that adding an object with `misp_event.add_object(**obj)` drops the references added earlier with `obj.add_reference(...)`: a standalone `MISPObject` does not serialise `ObjectReference`, so the unpacked dict never carries them. Passing the instance (`misp_event.add_object(obj)`) keeps them. This module uses the instance form; other modules that use the `**obj` form after `add_reference` may be affected.

Author: Daniel López (TweetFeed maintainer).
